### PR TITLE
pdf output: Fix subertabular early pagebreaks

### DIFF
--- a/src/system_pp.ml
+++ b/src/system_pp.ml
@@ -600,7 +600,7 @@ let pp_systemdefn_core_tex m sd lookup oi =
         (Grammar_pp.pp_tex_FIRST_LONG_PROD_NAME m ) (Grammar_pp.pp_tex_LONG_PROD_NAME m);
       Printf.fprintf fd ("\\newcommand{%s}[6]{%s{#1}{#2}{#3}{#4}{#5}{#6}}\n")
         (Grammar_pp.pp_tex_BINDSPEC_PROD_NAME m ) (Grammar_pp.pp_tex_PROD_NAME m);
-      Printf.fprintf fd ("\\newcommand{%s}{\\\\}\n") (Grammar_pp.pp_tex_PROD_NEWLINE_NAME m );
+      Printf.fprintf fd ("\\newcommand{%s}{\\\\\\shrinkheight{1pt}}\n") (Grammar_pp.pp_tex_PROD_NEWLINE_NAME m );
       Printf.fprintf fd ("\\newcommand{%s}{\\\\[5.0mm]}\n") (Grammar_pp.pp_tex_INTERRULE_NAME m );
       Printf.fprintf fd ("\\newcommand{%s}{\\\\}\n") (Grammar_pp.pp_tex_AFTERLASTRULE_NAME m );
       Embed_pp.pp_embeds fd m sd.syntax lookup sd.syntax.xd_embed_preamble;


### PR DESCRIPTION
Hi,

Let's consider the following example (sorry for the long example, it is needed):
```
metavar x ::=
metavar y ::=
metavar z ::=
metavar a ::=

grammar
  t :: t_ ::=
    | x            :: :: var1
    | x            :: :: var2
    | x            :: :: var3
    | x            :: :: var4
    | x            :: :: var5
    | x            :: :: var6
    | x            :: :: var7
    | x            :: :: var8
    | x            :: :: var9
    | x            :: :: var10
    | x            :: :: var11
    | x            :: :: var12
    | x            :: :: var13
    | x            :: :: var14
    | x            :: :: var15
    | x            :: :: var16
    | x            :: :: var17
    | x            :: :: var18
    | x            :: :: var19
    | x            :: :: var20
    | x            :: :: var21
    | x            :: :: var22
    | x            :: :: var23
    | x            :: :: var24
    | x            :: :: var26
    | x            :: :: var27
    | x            :: :: var28
    | x            :: :: var29
    | x            :: :: var30
    | x            :: :: var31
    | x            :: :: var32
    | x            :: :: var33
    | x            :: :: var34
    | x            :: :: var35
    | x            :: :: var36
    | x            :: :: var37
```
If you compile this to a tex file and then to a pdf using rubber, it will produce a nice 2 page pdf.
But if you add only one meta variable (lets say ```metavar b ::=```), then a pagebreak will occure after the metavariables being listed.

As describe in the documentation of subertabular (used in the produced latex file):
```
if accidentally the last line of the tabular produces a newpage, on the next page the tabletail will be written immediately after the tablehead. Depending on the contents this may result in an error message regarding misplaced \noalign.
A quick but not very elegant solution: shrink the allowed height of the table with the command \shrinkheight{...pt} after the first \\ of the supertabular.
```
Source: http://mirror.utexas.edu/ctan/macros/latex/contrib/supertabular/supertabular.pdf

The documentation doesn't say anything about the value of ```shrinkheight```, but ```2pt``` seems to work. I don't know if putting it after each newline is a good thing or not but it seems to work on my examples.