### PR TITLE
switch to using Type instead of Set in Coq list functions

### DIFF
--- a/coq/ott_list_core.v
+++ b/coq/ott_list_core.v
@@ -7,7 +7,7 @@ Set Implicit Arguments.
 
 
 Section list_predicates.
-Variable (A : Set). (* should be Type in coq >= V8.1 *)
+Variable (A : Type).
 
 (* Test whether a predicate [p] holds for every element of a list [l]. *)
 Definition forall_list (p:A->bool) (l:list A) :=
@@ -35,7 +35,7 @@ Hint Constructors Forall_list Exists_list.
 Section list_mem.
 (* Functions about membership in a list, with equality between a list
    element and a potential member being decided by [eq_dec]. *)
-Variable (A : Set). (* should be Type in coq >= V8.1 *)
+Variable (A : Type).
 Variable (eq_dec : forall (a b:A), {a=b} + {a<>b}).
 
 (* Test whether [x] appears in [l]. *)
@@ -57,7 +57,7 @@ End list_mem.
 
 
 Section Flat_map_definition.
-Variables (A B : Set). (* should be Type in coq >= V8.1 *)
+Variables (A B : Type).
 Variable (f : A -> list B).
 (* This definition is almost the same as the one in the standard library of
    Coq V8.0 or V8.1. The difference is that this version has the shape

--- a/coq/ott_list_eq_dec.v
+++ b/coq/ott_list_eq_dec.v
@@ -13,8 +13,7 @@ Set Implicit Arguments.
    you have to set up the induction manually and call [list_eq_dec] on
    your own (TODO: point to an example --- it's systematic but not easy). *)
 Lemma list_eq_dec :
-  forall (A:Set) (* should be Type in coq >= V8.1 *)
-         (eq_dec : forall (x y:A), {x = y} + {x <> y}),
+  forall (A:Type) (eq_dec : forall (x y:A), {x = y} + {x <> y}),
     forall (x y:list A), {x = y} + {x <> y}.
 Proof.
   induction x as [| a l IHl]; destruct y as [| a0 l0]; auto with datatypes.
@@ -31,7 +30,7 @@ Defined.
    pairs on its own, adding the following lemmas in the hint database helps
    when lists of pairs are involved. *)
 Lemma pair_eq_dec :
-  forall (A B:Set) (* should be Type in coq >= V8.1 *)
+  forall (A B:Type)
          (eqA:forall a a0:A, {a=a0}+{a<>a0})
          (eqB:forall b b0:B, {b=b0}+{b<>b0})
          (x y:A*B), {x=y}+{x<>y}.


### PR DESCRIPTION
The Ott Coq library currently uses the `Set` universe for many of its utility functions on lists. This is a serious restriction when one is working with things in the `Type` universe, which is arguably a common scenario nowadays. This pull request updates list definitions to use `Type` instead. The "tradeoff" is that compatibility with (very) old Coq versions is lost.