### PR TITLE
Enable safe-string compatiblity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.cmo
 *.cmx
 *.o
+*.annot
 src/ott
 grammar_lexer.ml
 grammar_lexer.o

--- a/ocamlgraph-safe-string.patch
+++ b/ocamlgraph-safe-string.patch
@@ -1,0 +1,19 @@
+diff --git a/lib/bitv.ml b/lib/bitv.ml
+index 28d0ac5..23f5325 100644
+--- a/lib/bitv.ml
++++ b/lib/bitv.ml
+@@ -449,11 +449,11 @@ let all_ones v =
+ 
+ let to_string v =
+   let n = v.length in
+-  let s = String.make n '0' in
++  let s = Buffer.create n in
+   for i = 0 to n - 1 do
+-    if unsafe_get v i then s.[i] <- '1'
++    Buffer.add_char s (if unsafe_get v i then '1' else '0')
+   done;
+-  s
++  Buffer.contents s
+ 
+ let print fmt v = Format.pp_print_string fmt (to_string v)
+ 

--- a/src/Makefile
+++ b/src/Makefile
@@ -222,6 +222,7 @@ version.tex: tmp_date.txt version_src.tex
 ## Rules to unpack and build our copy of ocamlgraph.
 $(OCAMLGRAPHDIR)/Makefile:
 	cd $(topdir) && tar -zxvf $(OCAMLGRAPHTARGZ)
+	cd $(OCAMLGRAPHDIR) && patch -p1 < $(topdir)/ocamlgraph-safe-string.patch
 	cd $(OCAMLGRAPHDIR) && ./configure
 $(OCAMLGRAPHDIR)/graph.cma: $(OCAMLGRAPHDIR)/Makefile
 	cd $(OCAMLGRAPHDIR) && $(MAKE) graph.cma

--- a/src/Makefile
+++ b/src/Makefile
@@ -233,14 +233,15 @@ $(OCAMLGRAPHDIR)/graph.cmxa: $(OCAMLGRAPHDIR)/Makefile
 # PR#4124 (present in OCaml 3.09.*).
 ocamlgraph: $(OCAMLGRAPHDIR)/graph.cma $(OCAMLGRAPHDIR)/graph.cmxa
 
-install.byt: $(OCAMLGRAPHDIR)/graph.cma
+$(topdir)/bin:
+	mkdir $(topdir)/bin
+
+install.byt: $(topdir)/bin $(OCAMLGRAPHDIR)/graph.cma
 	$(MAKE) byt
-	-mkdir $(topdir)/bin
 	cp ./ott $(topdir)/bin/ott
 
-install: $(OCAMLGRAPHDIR)/graph.cmxa
+install: $(topdir)/bin $(OCAMLGRAPHDIR)/graph.cmxa
 	$(MAKE) opt
-	-mkdir $(topdir)/bin
 	cp ./ott $(topdir)/bin/ott
 
 
@@ -357,6 +358,7 @@ clean:
 	rm -f tmp_*.ott
 	rm -f testRegr*
 	rm -f *Theory.* *.ui *.uo
+	rm -rf $(OCAMLGRAPHDIR)
 
 realclean:
 	rm -f .depend

--- a/src/auxl.ml
+++ b/src/auxl.ml
@@ -202,14 +202,9 @@ let char_list_of_string s =
 
 let string_of_char_list ts =
   let n = List.length ts in
-  let s = String.create n in
-  let rec f i ts = 
-    match ts with 
-    | [] -> ()
-    | t::ts -> String.set s i t; f (i+1) ts
-  in 
-  f 0 ts; 
-  s
+  let s = Buffer.create n in
+  List.iter (Buffer.add_char s) ts;
+  Buffer.contents s
 
 (* tests to identify strings *)
 
@@ -1841,6 +1836,6 @@ let string_of_filename filename =
   let ic = open_in filename in
   let _ = set_binary_mode_in ic true in
   let len = in_channel_length ic in
-  let buff = String.create len  in
-  let _ = really_input ic buff 0 len in
-  buff
+  let buff = Buffer.create len  in
+  Buffer.add_channel buff ic len;
+  Buffer.contents buff


### PR DESCRIPTION
Currently ott fails to compile using any safe-string opam switches. This PR fixes the issue alongside some general fixes.

Related to https://github.com/backtracking/ocamlgraph/pull/60.