### PR TITLE
adjust _CoqProject to support Coq 8.7

### DIFF
--- a/coq/.gitignore
+++ b/coq/.gitignore
@@ -1,5 +1,5 @@
 *.vo
 *.glob
 *.v.d
-*.vo.aux
+*.aux
 Makefile.coq

--- a/coq/_CoqProject
+++ b/coq/_CoqProject
@@ -1,14 +1,14 @@
 -Q . Ott
 
-ott_list_predicate.v
-ott_list_takedrop.v
-ott_list.v
-ott_list_repeat.v
-ott_list_mem.v
-ott_list_base.v
-ott_list_eq_dec.v
-ott_list_support.v
-ott_list_nth.v
-ott_list_core.v
-ott_list_distinct.v
-ott_list_flat_map.v
+./ott_list_predicate.v
+./ott_list_takedrop.v
+./ott_list.v
+./ott_list_repeat.v
+./ott_list_mem.v
+./ott_list_base.v
+./ott_list_eq_dec.v
+./ott_list_support.v
+./ott_list_nth.v
+./ott_list_core.v
+./ott_list_distinct.v
+./ott_list_flat_map.v


### PR DESCRIPTION
Coq 8.7 refactors the `coq_makefile` tool used to build projects. This necessitates a small backwards-compatible adjustment having to be made to the `_CoqProject` file in the `coq` directory. I also adjusted the Coq-specific `.gitignore` to cover new names for book-keeping (`aux`) files.