### PR TITLE
update OPAM library package definition for Coq 8.7

### DIFF
--- a/coq-ott.opam
+++ b/coq-ott.opam
@@ -10,7 +10,7 @@ license: "part BSD3, part LGPL 2.1"
 build: [ make "-j%{jobs}%" "-C" "coq" ]
 install: [ make "-C" "coq" "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Ott'" ]
-depends: [ "coq" {((>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~"))} ]
+depends: [ "coq" {((>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~") | (>= "8.7" & < "8.8~"))} ]
 
 tags: [
   "category:Computer Science/Semantics and Compilation/Semantics"

--- a/coq/.gitignore
+++ b/coq/.gitignore
@@ -3,3 +3,4 @@
 *.v.d
 *.aux
 Makefile.coq
+Makefile.coq.conf

--- a/coq/Makefile
+++ b/coq/Makefile
@@ -12,4 +12,4 @@ clean:
 	  $(MAKE) -f Makefile.coq cleanall; fi
 	rm -f Makefile.coq
 
-.PHONY: default clean quick install
+.PHONY: default clean install


### PR DESCRIPTION
Coq 8.7.0 is now out, and the OPAM package definition should reflect that this version is supported; hence this PR, which I tested locally with all supported Coq versions. Also, I include two miniscule administrative fixes related to the Coq library.

I have a bunch of Ott-dependent projects I want to migrate to Coq 8.7.0, and it would be great to have them rely on a released version of Ott. However, Ott 0.26 doesn't support Coq 8.7.0. Is there any chance of a 0.27 Ott release in the near future @PeterSewell & @hannesm? Getting rid of the default debug output on stdout that 0.26 has would be another benefit. I volunteer to shepherd Coq OPAM packages for any releases into the official Coq OPAM repo.