### PR TITLE
fix Coq compilation of caml_typedef.v in OCaml Light example

### DIFF
--- a/examples/ocaml_light/syntax.ott
+++ b/examples/ocaml_light/syntax.ott
@@ -155,8 +155,9 @@ Require Ascii.
 Require Import BinInt.
 Require String.
 Require Import Zdiv.
-Require Import ott_list.
+Require Import Ott.ott_list.
 Require Import caml_lib_misc.
+Require Import Sorting.Permutation.
 }}
 
 {{ hol

--- a/src/grammar_pp.ml
+++ b/src/grammar_pp.ml
@@ -2668,19 +2668,18 @@ and pp_rule m xd r = (* returns a string option *)
                      r.rule_ps))
            ^ "")
   | Coq co ->
-     pp_internal_coq_buffer :=
-        !pp_internal_coq_buffer ^
+      pp_internal_coq_buffer := !pp_internal_coq_buffer ^
         coq_maybe_decide_equality m xd r.rule_homs (Ntr r.rule_ntr_name);
-    if r.rule_meta || r.rule_phantom
-    then None
-    else
-      let universe = try pp_hom_spec m xd (List.assoc "coq-universe" r.rule_homs) with Not_found -> "Set" in
-      Some
-        (pp_nontermroot_ty m xd r.rule_ntr_name ^ " : "^universe^ " := "^pp_com^"\n"
-         ^ String.concat "\n"
-           (Auxl.option_map
-	      (pp_prod m xd r.rule_ntr_name r.rule_pn_wrapper)
-              r.rule_ps))
+      if r.rule_meta || r.rule_phantom
+      then None
+      else
+        let universe = try pp_hom_spec m xd (List.assoc "coq-universe" r.rule_homs) with Not_found -> "Set" in
+        Some
+          (pp_nontermroot_ty m xd r.rule_ntr_name ^ " : "^universe^ " := "^pp_com^"\n"
+           ^ String.concat "\n"
+             (Auxl.option_map
+                (pp_prod m xd r.rule_ntr_name r.rule_pn_wrapper)
+                r.rule_ps))
   | Rdx ro ->
       if r.rule_meta || r.rule_phantom 
       then None

--- a/src/grammar_pp.ml
+++ b/src/grammar_pp.ml
@@ -2667,17 +2667,20 @@ and pp_rule m xd r = (* returns a string option *)
 		     (pp_prod m xd r.rule_ntr_name r.rule_pn_wrapper) 
                      r.rule_ps))
            ^ "")
-  | Coq co -> 
-      if r.rule_meta || r.rule_phantom 
-      then None
-      else
-        let universe = try pp_hom_spec m xd (List.assoc "coq-universe" r.rule_homs) with Not_found -> "Set" in
-        Some 
-          (pp_nontermroot_ty m xd r.rule_ntr_name ^ " : "^universe^ " := "^pp_com^"\n" 
-           ^ String.concat "\n" 
-               (Auxl.option_map 
-		  (pp_prod m xd r.rule_ntr_name r.rule_pn_wrapper)
-                  r.rule_ps))
+  | Coq co ->
+     pp_internal_coq_buffer :=
+        !pp_internal_coq_buffer ^
+        coq_maybe_decide_equality m xd r.rule_homs (Ntr r.rule_ntr_name);
+    if r.rule_meta || r.rule_phantom
+    then None
+    else
+      let universe = try pp_hom_spec m xd (List.assoc "coq-universe" r.rule_homs) with Not_found -> "Set" in
+      Some
+        (pp_nontermroot_ty m xd r.rule_ntr_name ^ " : "^universe^ " := "^pp_com^"\n"
+         ^ String.concat "\n"
+           (Auxl.option_map
+	      (pp_prod m xd r.rule_ntr_name r.rule_pn_wrapper)
+              r.rule_ps))
   | Rdx ro ->
       if r.rule_meta || r.rule_phantom 
       then None


### PR DESCRIPTION
These changes fix Coq compilation of the file `caml_typedef.v` in the OCaml Light example. Tested on Coq versions 8.5.3 and 8.7.1.

The main problem was that decision procedures (`eq_*` lemmas) for non-metavars with `coq-equality` were not outputted properly due to a regression introduced between Ott 0.25 and 0.26 in commit fa0ecceb9fa2315.