### PR TITLE
Document how to load opam-installed emacs ott mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,8 @@ Ott Emacs directory.
 For installations using OPAM on \*nix systems, it is sufficient to use the following code, which will call `opam config var prefix` at load-time.
 
 ```ELisp
-(add-to-list 'load-path
-              (concat (let ((coding-system-for-read 'utf-8))
-                        (shell-command-to-string "printf %s \"$(opam config var prefix)\""))
-                      "/share/emacs/site-lisp"))
+(setq opam-share (substring (shell-command-to-string "opam config var share") 0 -1))
+(add-to-list 'load-path (concat opam-share "/emacs/site-lisp"))
 (require 'ott-mode)
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ Ott Emacs directory.
 (require 'ott-mode)
 ```
 
+For installations using OPAM on \*nix systems, it is sufficient to use the following code, which will call `opam config var prefix` at load-time.
+
+```ELisp
+(add-to-list 'load-path
+              (concat (let ((coding-system-for-read 'utf-8))
+                        (shell-command-to-string "printf %s \"$(opam config var prefix)\""))
+                      "/share/emacs/site-lisp"))
+(require 'ott-mode)
+```
+
 ### Visual Studio Code
 
 There is a [plugin for VSCode](https://marketplace.visualstudio.com/items?itemName=JoeyEremondi.ott), which features syntax highlighting and inline error reporting. 


### PR DESCRIPTION
This code should autodetect and load OPAM-installed ott.

I'm not sure there's much reason to keep the old code, or to not refactor it using `add-to-list`, but I've been conservative.