### PR TITLE
Consistently use the Type universe in the Coq library

### DIFF
--- a/coq/ott_list_base.v
+++ b/coq/ott_list_base.v
@@ -27,7 +27,7 @@ Ltac reverse_list l l' :=
 
 Section Lists.
 
-Variables A B C : Set.
+Variables A B C : Type.
 Implicit Types x : A.
 Implicit Types y : B.
 Implicit Types z : C.
@@ -44,8 +44,8 @@ Set Implicit Arguments.
 
 (*** Length ***)
 
-Definition lt_length (A:Set) := ltof _ (@length A).
-Definition well_founded_lt_length (A:Set) := (well_founded_ltof _ (@length A)).
+Definition lt_length (A:Type) := ltof _ (@length A).
+Definition well_founded_lt_length (A:Type) := (well_founded_ltof _ (@length A)).
 
 Lemma length_app : forall l l', length (l ++ l') = length l + length l'.
 Proof.

--- a/coq/ott_list_distinct.v
+++ b/coq/ott_list_distinct.v
@@ -14,7 +14,7 @@ Require Import Omega.
 
 Section All_distinct.
 Set Implicit Arguments.
-Variable A : Set.
+Variable A : Type.
 Variable eq_dec : forall (x y:A), {x=y} + {x<>y}.
 
 Notation one_distinct := (fun x xs => negb (list_mem eq_dec x xs)).

--- a/coq/ott_list_flat_map.v
+++ b/coq/ott_list_flat_map.v
@@ -9,7 +9,7 @@ Require Import Ott.ott_list_base.
 
 
 Section Flat_map.
-Variables A B C : Set.
+Variables A B C : Type.
 Implicit Types x : A.
 Implicit Types y : B.
 Implicit Types l xs : list A.

--- a/coq/ott_list_mem.v
+++ b/coq/ott_list_mem.v
@@ -14,7 +14,7 @@ Set Implicit Arguments.
 (*** Membership predicate ***)
 
 Section In.
-Variable A : Set.
+Variable A : Type.
 Implicit Types x : A.
 Implicit Types xs l : list A.
 
@@ -58,14 +58,14 @@ Hint Resolve nth_error_In nth_safe_In : datatypes.
 (*** Membership predicate and map ***)
 
 Lemma image_In_map :
-  forall (A B:Set) x l (f:A->B),
+  forall (A B:Type) x l (f:A->B),
     In x l -> In (f x) (map f l).
 Proof.
   intros. induction l; simpl in * . tauto. destruct H; subst; tauto.
 Qed.
 
 Lemma In_map_exists :
-  forall (A B:Set) l y (f:A->B),
+  forall (A B:Type) l y (f:A->B),
     In y (map f l) -> exists x, y = f x /\ In x l.
 Proof.
   intros. induction l; simpl in * . tauto. destruct H. eauto. firstorder.
@@ -93,7 +93,7 @@ Ltac elim_all_In_map :=
 (*** Membership function ***)
 
 Section list_mem.
-Variable A : Set.
+Variable A : Type.
 Variable (eq_dec : forall (a b:A), {a=b} + {a<>b}).
 Implicit Types x : A.
 Implicit Types xs l : list A.
@@ -169,7 +169,7 @@ Hint Rewrite list_mem_app : lists.
 (*** Removing an element ***)
 
 Section list_minus.
-Variable A : Set.
+Variable A : Type.
 Variable (eq_dec : forall (a b:A), {a=b} + {a<>b}).
 Implicit Types x : A.
 Implicit Types xs l : list A.

--- a/coq/ott_list_nth.v
+++ b/coq/ott_list_nth.v
@@ -8,7 +8,7 @@ Require Import Ott.ott_list_base.
 
 Section Lists.
 
-Variables A B C : Set.
+Variables A B C : Type.
 Implicit Types x : A.
 Implicit Types y : B.
 Implicit Types z : C.

--- a/coq/ott_list_predicate.v
+++ b/coq/ott_list_predicate.v
@@ -12,7 +12,7 @@ Require Import Ott.ott_list_takedrop.
 Section List_predicate_inductive.
 (* Properties of [Forall_list] and [Exists_list] *)
 
-Variables A : Set.
+Variables A : Type.
 Implicit Types x : A.
 Implicit Types xs l : list A.
 Implicit Types p : A -> bool.
@@ -184,7 +184,7 @@ Hint Resolve Forall_list_implies Exists_list_implies : lists.
 Section List_predicate_fold.
 (* Properties of [forall_list] and [exists_list] *)
 
-Variables A : Set.
+Variables A : Type.
 Implicit Types x : A.
 Implicit Types xs l : list A.
 Implicit Types p : A -> bool.
@@ -265,7 +265,7 @@ End List_predicate_fold.
 
 Section List_predicate_relationship.
 
-Variables A : Set.
+Variables A : Type.
 Implicit Types x : A.
 Implicit Types xs l : list A.
 Implicit Types p : A -> bool.
@@ -296,7 +296,7 @@ End List_predicate_relationship.
 
 Section List_predicate_map.
 
-Variables A B C : Set.
+Variables A B C : Type.
 Implicit Types x : A.
 Implicit Types y : B.
 Implicit Types z : C.

--- a/coq/ott_list_repeat.v
+++ b/coq/ott_list_repeat.v
@@ -12,7 +12,7 @@ Import List_lib_Arith.
 
 Section Lists.
 
-Variables A B C : Set.
+Variables A B C : Type.
 Implicit Types x : A.
 Implicit Types y : B.
 Implicit Types z : C.

--- a/coq/ott_list_support.v
+++ b/coq/ott_list_support.v
@@ -24,7 +24,7 @@ End List_lib_Arith.
 
 Section functions.
   Set Implicit Arguments.
-  Variables A B C D : Set.
+  Variables A B C D : Type.
   Definition compose (g:B->C) (f:A->B) x := g (f x).
   Definition compose2 (h:B->C->D) (f:A->B) (g:A->C) x y := h (f x) (g y).
 End functions.
@@ -34,7 +34,7 @@ Hint Unfold compose compose2.
 
 Section option.
   Set Implicit Arguments.
-  Variables A B : Set.
+  Variables A B : Type.
 
   Definition map_option (f:A->B) (xo:option A) : option B :=
     match xo with

--- a/coq/ott_list_takedrop.v
+++ b/coq/ott_list_takedrop.v
@@ -14,7 +14,7 @@ Import List_lib_Arith.
 
 Section Lists.
 
-Variables A B C : Set.
+Variables A B C : Type.
 Implicit Types x : A.
 Implicit Types y : B.
 Implicit Types z : C.


### PR DESCRIPTION
While I was cleaning out deprecated Coq code, I noticed that the Coq library was still using the restrictive `Set` universe for its functions on lists. The convention in the Coq standard library nowadays is to consistently use the `Type` universe instead for such functions, so I changed them. Since all terms in `Set` are also in `Type`, this should be a completely backwards-compatible change, and indeed it works with, e.g., `ocaml_light` for Coq 8.5.3, 8.6.1, 8.7.2, and 8.8.0.