### PR TITLE
Add -generate_aux_rules false when generating PDF

### DIFF
--- a/tests/menhir_tests/test10menhir_with_aux/Makefile
+++ b/tests/menhir_tests/test10menhir_with_aux/Makefile
@@ -24,11 +24,11 @@ $(ROOT)_ast.ml  $(ROOT)_lexer.mll $(ROOT)_parser.mly $(ROOT)_parser_pp.ml $(ROOT
 
 
 $(ROOT)_quotiented.pdf: $(ROOT).ott Makefile
-	$(OTT) -quotient_rules true -i $(ROOT).ott -o $(ROOT)_quotiented.tex
+	$(OTT) -quotient_rules true -generate_aux_rules false -i $(ROOT).ott -o $(ROOT)_quotiented.tex
 	pdflatex $(ROOT)_quotiented.tex
 
 $(ROOT)_unquotiented.pdf: $(ROOT).ott Makefile
-	$(OTT) -quotient_rules false -i $(ROOT).ott -o $(ROOT)_unquotiented.tex
+	$(OTT) -quotient_rules false -generate_aux_rules false  -aux_style_rules false -i $(ROOT).ott -o $(ROOT)_unquotiented.tex
 	pdflatex $(ROOT)_unquotiented.tex
 
 clean:


### PR DESCRIPTION
Fixes the issue I reported earlier that LaTeX productions included the loc info.
Since this test also serves as a model for how to use the {{ aux _ l }} rules, it seems like a good idea to fix it?