### PR TITLE
Consistent error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ version.tex
 bin/
 .depend
 ocamlgraph-1.7
+.merlin
+make_merlin.sh

--- a/src/auxl.ml
+++ b/src/auxl.ml
@@ -631,6 +631,13 @@ let hom_spec_for_hom_name hn homs =
 let hom_spec_for_pp_mode m homs = 
   hom_spec_for_hom_name (hom_name_for_pp_mode m) homs
 
+let loc_of_symterm st = match st with
+  | St_node (l,_) -> l  
+  | St_nonterm (l,_,_) -> l
+  | St_nontermsub (l,_,_,_) -> l 
+  | St_uninterpreted (l,_) -> l
+   
+
 let loc_of_raw_element e = 
   match e with
   | Raw_ident (l,_) 

--- a/src/auxl.ml
+++ b/src/auxl.ml
@@ -31,7 +31,8 @@
 (*  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                         *)
 (**************************************************************************)
 
-open Types
+open Types;;
+open Location
 
 (* exceptions ************************************************************ *)
 
@@ -52,16 +53,22 @@ let mode_name m = match m with
   | Lex _ -> "Lex"
   | Menhir _ -> "Menhir"
 
+let maybe_pp_loc l = 
+  match l with
+    | None -> ""
+    | Some l -> pp_loc l ^ ": "
+  ;;
+
 let debug_on = false
 
 let debug s = if debug_on then begin print_string s; flush stdout end
 
-let warning l s = print_endline ("warning: " ^ s); flush stdout
+let warning l s = print_endline ("warning: " ^ maybe_pp_loc l ^ s); flush stdout
 
-let report_error l s = print_endline ("error: " ^ s); flush stdout
+let report_error l s = print_endline ("error: " ^ maybe_pp_loc l ^ s); flush stdout
 
 
-let error l s = print_endline ("error: " ^ s); flush stdout; exit 2
+let error l s = print_endline ("error: " ^ maybe_pp_loc l ^ s); flush stdout; exit 2
 
 let int_error s = print_endline("internal: " ^ s); flush stdout; exit 2
 

--- a/src/auxl.ml
+++ b/src/auxl.ml
@@ -636,7 +636,12 @@ let loc_of_symterm st = match st with
   | St_nonterm (l,_,_) -> l
   | St_nontermsub (l,_,_,_) -> l 
   | St_uninterpreted (l,_) -> l
-   
+
+let loc_of_ntr (xd:syntaxdefn) (ntr:nontermroot) =
+  (rule_of_ntr xd ntr).rule_loc 
+
+let loc_of_prodname ?(warn=true) (xd:syntaxdefn) (pn:prodname) =
+  (prod_of_prodname xd pn).prod_loc 
 
 let loc_of_raw_element e = 
   match e with

--- a/src/auxl.ml
+++ b/src/auxl.ml
@@ -53,22 +53,27 @@ let mode_name m = match m with
   | Lex _ -> "Lex"
   | Menhir _ -> "Menhir"
 
+let colour = ref true
+
 let maybe_pp_loc l = 
   match l with
     | None -> ""
-    | Some l -> pp_loc l ^ ": "
-  ;;
+    | Some l -> if !colour then "\027[1m" ^ pp_loc l ^ ":\027[0m\n" else pp_loc l ^ ":\n"
+
+let warning_string () = if !colour then "\027[1m\027[35mWarning: \027[0m" else "Warning: "
+
+let error_string () = if !colour then "\027[1m\027[31mError: \027[0m" else "Error: "
 
 let debug_on = false
 
 let debug s = if debug_on then begin print_string s; flush stdout end
 
-let warning l s = print_endline ("warning: " ^ maybe_pp_loc l ^ s); flush stdout
+let warning l s = print_endline (maybe_pp_loc l ^ warning_string () ^ s); flush stdout
 
-let report_error l s = print_endline ("error: " ^ maybe_pp_loc l ^ s); flush stdout
+let report_error l s = print_endline (maybe_pp_loc l ^ error_string () ^ s); flush stdout
 
 
-let error l s = print_endline ("error: " ^ maybe_pp_loc l ^ s); flush stdout; exit 2
+let error l s = print_endline (maybe_pp_loc l ^ error_string () ^ s); flush stdout; exit 2
 
 let int_error s = print_endline("internal: " ^ s); flush stdout; exit 2
 

--- a/src/auxl.ml
+++ b/src/auxl.ml
@@ -56,9 +56,9 @@ let debug_on = false
 
 let debug s = if debug_on then begin print_string s; flush stdout end
 
-let warning s = print_endline ("warning: " ^ s); flush stdout
+let warning l s = print_endline ("warning: " ^ s); flush stdout
 
-let error s = print_endline ("error: " ^ s); flush stdout; exit 2
+let error l s = print_endline ("error: " ^ s); flush stdout; exit 2
 
 let int_error s = print_endline("internal: " ^ s); flush stdout; exit 2
 
@@ -301,7 +301,7 @@ let prod_of_prodname ?(warn=true) (xd:syntaxdefn) (pn:prodname) : prod =
       List.find 
 	(fun r -> List.exists (fun p -> p.prod_name=pn) r.rule_ps)
 	xd.xd_rs
-    with Not_found -> if warn then warning ("internal: prod_of_prodname: searching pn = "^pn^"\n"); raise Not_found in
+    with Not_found -> if warn then warning None ("internal: prod_of_prodname: searching pn = "^pn^"\n"); raise Not_found in
   List.find (fun p -> p.prod_name=pn) r.rule_ps
 (*        let prod_of_prod_name : prodname -> prod  *)
 (*            = fun prod_name' ->  *)
@@ -1265,7 +1265,7 @@ let avoid xd mvs0 nts0 =
         match mvd.mvd_indexvar with
         | true ->
             if mvr=mvd.mvd_name then 
-              warning ("warning: indexvar \""^mvr^"\" is primary so may give a name-clash\n") ;
+              warning None ("warning: indexvar \""^mvr^"\" is primary so may give a name-clash\n") ;
             None
         | false ->
             if mvr=mvd.mvd_name then Some mv else None
@@ -1350,7 +1350,7 @@ let secondaryify xd mvs0 nts0 =
         match mvd.mvd_indexvar with
         | true ->
             if mvr=mvd.mvd_name then 
-              warning ("indexvar \""^mvr^"\" is primary so may give a name-clash\n") ;
+              warning None ("indexvar \""^mvr^"\" is primary so may give a name-clash\n") ;
             Some mv
         | false ->
             Some mv
@@ -1492,7 +1492,7 @@ let capitalize_prodnames sd =
   let map_prod_names = List.map (fun pn -> (pn,String.capitalize pn)) prod_name_list in
   let (conflict,err_msg) = detect_conflicts map_prod_names in
   if conflict
-  then error ("Renaming of production name \""^err_msg^"\" generates a conflict\n")
+  then error None ("Renaming of production name \""^err_msg^"\" generates a conflict\n")
   else map_prod_names
 
 let uncapitalize_prodnames sd =
@@ -1502,7 +1502,7 @@ let uncapitalize_prodnames sd =
   let map_prod_names = List.map (fun pn -> (pn,String.uncapitalize pn)) prod_name_list in
   let (conflict,err_msg) = detect_conflicts map_prod_names in
   if conflict
-  then error ("Renaming of production name \""^err_msg^"\" generates a conflict\n")
+  then error None ("Renaming of production name \""^err_msg^"\" generates a conflict\n")
   else map_prod_names
 
 let uncapitalize_primary_nontermroots sd = 
@@ -1511,7 +1511,7 @@ let uncapitalize_primary_nontermroots sd =
   let map_nontermroots = List.map (fun ntr -> (ntr,String.uncapitalize ntr)) nontermroots_list in
   let (conflict,err_msg) = detect_conflicts map_nontermroots in
   if conflict
-  then error ("Renaming of primary nontermroot \""^err_msg^"\" generates a conflict\n")
+  then error None ("Renaming of primary nontermroot \""^err_msg^"\" generates a conflict\n")
   else map_nontermroots
 
 let uncapitalize_primary_metavarroots sd =
@@ -1520,7 +1520,7 @@ let uncapitalize_primary_metavarroots sd =
   let map_metavarroots = List.map (fun mvr -> (mvr,String.uncapitalize mvr)) metavarroots_list in
   let (conflict,err_msg) = detect_conflicts map_metavarroots in
   if conflict
-  then error ("Renaming of primary metavar \""^err_msg^"\" generates a conflict\n")
+  then error None ("Renaming of primary metavar \""^err_msg^"\" generates a conflict\n")
   else map_metavarroots 
 
 let caml_rename sd =
@@ -1741,7 +1741,7 @@ let rec pp_tex_escape_alltt s =
 
 let isa_filename_check s =
   match string_remove_suffix s ".thy" with
-  | None -> error ("Isabelle filenames must end with .thy\n")
+  | None -> error None ("Isabelle filenames must end with .thy\n")
   | Some s1 -> s1
 
 let hol_filename_check s =

--- a/src/auxl.ml
+++ b/src/auxl.ml
@@ -1129,8 +1129,8 @@ and rename_freevar map fv =
     fv_that = rename_nt_or_mv_root map fv.fv_that; }
 
 and rename_parsing_annotations map pas =
-  { pa_data = List.map (fun (ntr1,pa_type,ntr2)-> 
-      (rename_nontermroot map ntr1,pa_type,rename_nontermroot map ntr2)) pas.pa_data }
+  { pa_data = List.map (fun (ntr1,pa_type,ntr2,l)-> 
+      (rename_nontermroot map ntr1,pa_type,rename_nontermroot map ntr2,l)) pas.pa_data }
 
 and rename_dependencies map xddep =
   { xd_dep_ts = List.map (List.map (rename_nt_or_mv_root map)) xddep.xd_dep_ts;

--- a/src/auxl.ml
+++ b/src/auxl.ml
@@ -637,6 +637,14 @@ let loc_of_symterm st = match st with
   | St_nontermsub (l,_,_,_) -> l 
   | St_uninterpreted (l,_) -> l
 
+let loc_of_symterm_element ste = match ste with
+  | Types.Ste_st (loc,_) -> loc
+  | Types.Ste_metavar (loc,_,_) -> loc
+  | Types.Ste_var (loc,_,_) -> loc
+  | Types.Ste_list (loc,_) -> loc
+
+let loc_of_mvr xd mvr = (mvd_of_mvr_nonprimary xd mvr).mvd_loc
+
 let loc_of_ntr (xd:syntaxdefn) (ntr:nontermroot) =
   (rule_of_ntr xd ntr).rule_loc 
 

--- a/src/auxl.ml
+++ b/src/auxl.ml
@@ -74,9 +74,9 @@ let warning l s = print_endline (maybe_pp_loc l ^ warning_string () ^ s); flush 
 let report_error l s = print_endline (maybe_pp_loc l ^ error_string () ^ s); flush stdout
 
 
-let error l s = raise (Located_Failure (l, maybe_pp_loc l ^ error_string () ^ s))
+let error l s = raise (Located_Failure (l, s))
 
-let exit_with l s = (maybe_pp_loc l ^ error_string () ^ s);  flush stdout; exit 2
+let exit_with l s = print_endline (maybe_pp_loc l ^ error_string () ^ s);  flush stdout; exit 2
 
 let int_error s = raise (Located_Failure (None, "internal: " ^ s))
 

--- a/src/auxl.ml
+++ b/src/auxl.ml
@@ -37,6 +37,7 @@ open Location
 (* exceptions ************************************************************ *)
 
 exception ThisCannotHappen
+exception Located_Failure of (loc option)*string
 
 (* debug, warning and error report *************************************** *)
 
@@ -73,11 +74,13 @@ let warning l s = print_endline (maybe_pp_loc l ^ warning_string () ^ s); flush 
 let report_error l s = print_endline (maybe_pp_loc l ^ error_string () ^ s); flush stdout
 
 
-let error l s = print_endline (maybe_pp_loc l ^ error_string () ^ s); flush stdout; exit 2
+let error l s = raise (Located_Failure (l, maybe_pp_loc l ^ error_string () ^ s))
 
-let int_error s = print_endline("internal: " ^ s); flush stdout; exit 2
+let exit_with l s = (maybe_pp_loc l ^ error_string () ^ s);  flush stdout; exit 2
 
-let errorm m s = print_endline ("internal (" ^ mode_name m ^ "): " ^ s); flush stdout; exit 2
+let int_error s = raise (Located_Failure (None, "internal: " ^ s))
+
+let errorm m s = raise (Located_Failure (None, "internal (" ^ mode_name m ^ "): " ^ s))
 
 
 (* ***************** *)

--- a/src/auxl.ml
+++ b/src/auxl.ml
@@ -1062,11 +1062,11 @@ and rename_bound map b = match b with
                           bclu_upper = rename_suffix_item map bclu.bclu_upper }
                         
 and rename_bindspec map bs = match bs with
-| Bind(mse,nt)->Bind(rename_mse map mse,rename_nonterm map nt)
-| AuxFnDef(auxfn,mse)->AuxFnDef(auxfn, rename_mse map mse)
-| NamesEqual(mse,mse')->NamesEqual(rename_mse map mse,rename_mse map mse')
-| NamesDistinct(mse,mse')->NamesDistinct(rename_mse map mse,rename_mse map mse')
-| AllNamesDistinct(mse)->AllNamesDistinct(rename_mse map mse)
+| Bind(loc,mse,nt)->Bind(loc,rename_mse map mse,rename_nonterm map nt)
+| AuxFnDef(loc,auxfn,mse)->AuxFnDef(loc,auxfn, rename_mse map mse)
+| NamesEqual(loc,mse,mse')->NamesEqual(loc,rename_mse map mse,rename_mse map mse')
+| NamesDistinct(loc,mse,mse')->NamesDistinct(loc,rename_mse map mse,rename_mse map mse')
+| AllNamesDistinct(loc,mse)->AllNamesDistinct(loc,rename_mse map mse)
 
 and rename_mse map mse = match mse with
 | MetaVarExp(mv)->MetaVarExp(rename_metavar map mv)
@@ -1803,7 +1803,7 @@ let prod_require_nominal m xd p =
   List.exists
     ( fun bs -> 
       match bs with
-      | Bind (MetaVarExp (mvr,_), nt) -> 
+      | Bind (_, MetaVarExp (mvr,_), nt) -> 
 	  is_nominal_atom m xd (mvd_of_mvr xd (primary_mvr_of_mvr xd mvr) )
       | _ -> false )
     p.prod_bs

--- a/src/auxl.ml
+++ b/src/auxl.ml
@@ -58,6 +58,9 @@ let debug s = if debug_on then begin print_string s; flush stdout end
 
 let warning l s = print_endline ("warning: " ^ s); flush stdout
 
+let report_error l s = print_endline ("error: " ^ s); flush stdout
+
+
 let error l s = print_endline ("error: " ^ s); flush stdout; exit 2
 
 let int_error s = print_endline("internal: " ^ s); flush stdout; exit 2

--- a/src/bounds.ml
+++ b/src/bounds.ml
@@ -36,7 +36,7 @@ exception NotImplementedYet;;
 open Types;;
 open Location;;
 
-exception Bounds of loc option * string
+exception Bounds of loc * string
 
 
 (** ******************************** *)
@@ -55,7 +55,7 @@ let sie_null = [Si_punct ""]
 
 (* given a bounds environment be and a suffix suff, return at most one bound *)
 (* referenced in the suffix. fail if the suffix references >1 bound*)
-let findbounds (be : bound list) (suff : suffix) : bound option
+let findbounds (be : bound list) (suff : suffix) loc : bound option
     = let rec indices suff = 
       match suff with
       | [] -> []
@@ -66,8 +66,7 @@ let findbounds (be : bound list) (suff : suffix) : bound option
     | [] -> None
     | [i] -> (*print_string ("<<<< "^string_of_int i^" >>>>");flush stdout;*)
         Some(List.nth be i)
-        (* TODO *)
-    | _ -> raise (Bounds (None, "findbounds: multiple suffix indices in a suffix"))
+    | _ -> raise (Bounds (loc, "findbounds: multiple suffix indices in a suffix"))
 
 (* collect all the nonterms/metavars in a symterm *)
 (* (and their nontermsub-lower-and-top data if they have it), *)
@@ -76,13 +75,13 @@ let rec nt_or_mv_of_symterm (be : bound list) st
 : ((nt_or_mv * subntr_data) * bound option ) list = 
   match st with
   | St_node (_,stnb) -> nt_or_mv_of_symterm_node_body be stnb
-  | St_nonterm (_,_,(ntr,sf)) -> [ (((Ntr ntr),sf),None),findbounds be sf ]  
-  | St_nontermsub (_,ntrl,ntrt,(ntr,sf)) -> [(((Ntr ntr),sf),Some(ntrl,ntrt(*ntru*))),findbounds be sf ]
+  | St_nonterm (_,_,(ntr,sf)) -> [ (((Ntr ntr),sf),None),findbounds be sf (Auxl.loc_of_symterm st) ]  
+  | St_nontermsub (_,ntrl,ntrt,(ntr,sf)) -> [(((Ntr ntr),sf),Some(ntrl,ntrt(*ntru*))),findbounds be sf (Auxl.loc_of_symterm st) ]
   | St_uninterpreted (_,_)-> []
 and nt_or_mv_of_symterm_element be ste =
   match ste with
   | Ste_st (_,st) -> nt_or_mv_of_symterm be st
-  | Ste_metavar (_,_,(mvr,sf)) -> [ (((Mvr mvr),sf),None),findbounds be sf ]
+  | Ste_metavar (_,_,(mvr,sf)) -> [ (((Mvr mvr),sf),None),findbounds be sf (Auxl.loc_of_symterm_element ste) ]
   | Ste_var _ -> []
   | Ste_list (_,stlis)  -> 
       List.concat (List.map (nt_or_mv_of_symterm_list_item be) stlis)
@@ -103,7 +102,7 @@ let nt_or_mv_of_symterms sts =
 
 
 (* check for each Bound_dotform bound that it occurs with only one length constraint. Return the bounds without duplicates *)
-let check_length_consistency : 
+let check_length_consistency loc : 
     ((nt_or_mv* subntr_data) * bound option ) list ->  bound list 
         = 
       function xys ->
@@ -116,8 +115,7 @@ let check_length_consistency :
                 (try  (
                   let i=List.assoc (bd.bd_lower,bd.bd_upper) acc in
                   if i=bd.bd_length then f acc bounds' 
-                  (* TODO *)
-                  else raise (Bounds (None, "bound "^Grammar_pp.pp_plain_bound b^" has inconsistent length constraints, \""^Grammar_pp.pp_plain_dots i ^"\" and \""^ Grammar_pp.pp_plain_dots bd.bd_length ^ "\"")))
+                  else raise (Bounds (loc, "bound "^Grammar_pp.pp_plain_bound b^" has inconsistent length constraints, \""^Grammar_pp.pp_plain_dots i ^"\" and \""^ Grammar_pp.pp_plain_dots bd.bd_length ^ "\"")))
                 with
                   Not_found -> f (((bd.bd_lower,bd.bd_upper),bd.bd_length)::acc) bounds' )
             | b::bounds' -> f acc bounds' in
@@ -144,7 +142,7 @@ let check_length_consistency :
 
 (* check for each nt_or_mv (and subntr data) that it doesn't appear with *)
 (* multiple different bounds, and return a list without duplicates *)
-let check_bounds_consistency : 
+let check_bounds_consistency loc : 
     ((nt_or_mv*subntr_data) * bound option) list -> 
       ((nt_or_mv*subntr_data) * bound option) list 
         = function xbos ->
@@ -158,7 +156,7 @@ let check_bounds_consistency :
                     (if bo=bo' then f acc xbos'
                     else
                     (* TODO *)
-                      raise (Bounds (None, "inconsistent bounds for "^Grammar_pp.pp_plain_nt_or_mv (fst x)^": "^Grammar_pp.pp_plain_bound_option bo ^" and "^Grammar_pp.pp_plain_bound_option bo'  )))) in
+                      raise (Bounds (loc, "inconsistent bounds for "^Grammar_pp.pp_plain_nt_or_mv (fst x)^": "^Grammar_pp.pp_plain_bound_option bo ^" and "^Grammar_pp.pp_plain_bound_option bo'  )))) in
           f [] xbos
 
 (* split into those without a bound and those with one *)
@@ -331,10 +329,10 @@ let dotenv23 ntmvsn_without_bounds ntmvsn_with_bounds  =
 let bound_extraction m xd loc sts : dotenv * dotenv3 * string = 
   try  
     let x = nt_or_mv_of_symterms sts in
-    let bounds = check_length_consistency x in
+    let bounds = check_length_consistency loc x in
     let pp_bounds = String.concat "  " 
         (List.map Grammar_pp.pp_plain_bound bounds) in
-    let ntmvsn_with_boundopts = check_bounds_consistency x in
+    let ntmvsn_with_boundopts = check_bounds_consistency loc x in
     let ntmvsn_without_bounds,ntmvsn_with_bounds = split_bounded ntmvsn_with_boundopts in
     let bound_with_ntmvsnss = nt_or_mv_per_bound ntmvsn_with_bounds in
     let de1 = dotenv1 m xd bound_with_ntmvsnss in
@@ -350,7 +348,7 @@ let bound_extraction m xd loc sts : dotenv * dotenv3 * string =
         ^ Grammar_pp.pp_plain_dotenv de in
     de, de3, s
   with 
-    Bounds (_, s') -> raise (Bounds (Some loc, s'))
+    Bounds (_, s') -> raise (Bounds (loc, s'))
 (*  with e ->  *)
  (*   "exception in bound_extraction" *)
 

--- a/src/bounds.ml
+++ b/src/bounds.ml
@@ -31,12 +31,12 @@
 (*  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                         *)
 (**************************************************************************)
 
-exception NotImplementedYet;;
+exception NotImplementedYet;; 
 
 open Types;;
 open Location;;
 
-exception Bounds of string
+exception Bounds of loc option * string
 
 
 (** ******************************** *)
@@ -66,7 +66,8 @@ let findbounds (be : bound list) (suff : suffix) : bound option
     | [] -> None
     | [i] -> (*print_string ("<<<< "^string_of_int i^" >>>>");flush stdout;*)
         Some(List.nth be i)
-    | _ -> raise (Bounds "findbounds: multiple suffix indices in a suffix")
+        (* TODO *)
+    | _ -> raise (Bounds (None, "findbounds: multiple suffix indices in a suffix"))
 
 (* collect all the nonterms/metavars in a symterm *)
 (* (and their nontermsub-lower-and-top data if they have it), *)
@@ -115,7 +116,8 @@ let check_length_consistency :
                 (try  (
                   let i=List.assoc (bd.bd_lower,bd.bd_upper) acc in
                   if i=bd.bd_length then f acc bounds' 
-                  else raise (Bounds ("bound "^Grammar_pp.pp_plain_bound b^" has inconsistent length constraints, \""^Grammar_pp.pp_plain_dots i ^"\" and \""^ Grammar_pp.pp_plain_dots bd.bd_length ^ "\"")))
+                  (* TODO *)
+                  else raise (Bounds (None, "bound "^Grammar_pp.pp_plain_bound b^" has inconsistent length constraints, \""^Grammar_pp.pp_plain_dots i ^"\" and \""^ Grammar_pp.pp_plain_dots bd.bd_length ^ "\"")))
                 with
                   Not_found -> f (((bd.bd_lower,bd.bd_upper),bd.bd_length)::acc) bounds' )
             | b::bounds' -> f acc bounds' in
@@ -154,8 +156,9 @@ let check_bounds_consistency :
                 | None -> f ((x,bo)::acc) xbos'
                 | Some bo' -> 
                     (if bo=bo' then f acc xbos'
-                    else 
-                      raise (Bounds ("inconsistent bounds for "^Grammar_pp.pp_plain_nt_or_mv (fst x)^": "^Grammar_pp.pp_plain_bound_option bo ^" and "^Grammar_pp.pp_plain_bound_option bo'  )))) in
+                    else
+                    (* TODO *)
+                      raise (Bounds (None, "inconsistent bounds for "^Grammar_pp.pp_plain_nt_or_mv (fst x)^": "^Grammar_pp.pp_plain_bound_option bo ^" and "^Grammar_pp.pp_plain_bound_option bo'  )))) in
           f [] xbos
 
 (* split into those without a bound and those with one *)
@@ -347,7 +350,7 @@ let bound_extraction m xd loc sts : dotenv * dotenv3 * string =
         ^ Grammar_pp.pp_plain_dotenv de in
     de, de3, s
   with 
-    Bounds s' -> raise (Bounds (s'^" at "^Location.pp_loc loc))
+    Bounds (_, s') -> raise (Bounds (Some loc, s'))
 (*  with e ->  *)
  (*   "exception in bound_extraction" *)
 

--- a/src/bounds.mli
+++ b/src/bounds.mli
@@ -33,7 +33,7 @@
 
 open Types;;
 
-exception Bounds of loc option * string 
+exception Bounds of loc * string 
 val nt_or_mv_of_symterms : 
     Types.symterm list ->	 
     ((Types.nt_or_mv * Types.subntr_data) * Types.bound option) list

--- a/src/bounds.mli
+++ b/src/bounds.mli
@@ -31,7 +31,9 @@
 (*  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                         *)
 (**************************************************************************)
 
-exception Bounds of string
+open Types;;
+
+exception Bounds of loc option * string 
 val nt_or_mv_of_symterms : 
     Types.symterm list ->	 
     ((Types.nt_or_mv * Types.subntr_data) * Types.bound option) list

--- a/src/context_pp.ml
+++ b/src/context_pp.ml
@@ -84,7 +84,7 @@ let context_app_rhs m xd lookup (hole:nonterm) (target:nontermroot) (r:rule) (p:
 	( match m with
 	| Caml _ -> Auxl.capitalize_prodnames_in_symterm (List.hd sts)
 	| _ -> List.hd sts )
-      | _ -> Auxl.warning ("internal: multiple parses context fake rhs: "^fake_rhs^"\n"); List.hd sts in
+      | _ -> Auxl.warning None ("internal: multiple parses context fake rhs: "^fake_rhs^"\n"); List.hd sts in
     let sie = [] in
     let ((de1,de2) as de,de3,pptbe) = Bounds.bound_extraction m xd dummy_loc [sts_e]  in
     (true, Some (Grammar_pp.pp_symterm m xd sie de sts_e))

--- a/src/coq_induct.ml
+++ b/src/coq_induct.ml
@@ -50,7 +50,7 @@ let need_induction m xd r =
 	      | _ -> false)
 	    elb.elb_es
       | Lang_option _ | Lang_sugaroption _ -> 
-	  Auxl.error "interal: option types not implemented in pp_induction\n"
+	  Auxl.error None "interal: option types not implemented in pp_induction\n"
       | Lang_nonterm (_,_) | Lang_metavar (_,_) | Lang_terminal _ -> false
     in List.exists element_uses_list_nt p.prod_es in
   (not r.rule_meta) && (List.exists uses_list_nt r.rule_ps)

--- a/src/coq_induct.ml
+++ b/src/coq_induct.ml
@@ -50,7 +50,7 @@ let need_induction m xd r =
 	      | _ -> false)
 	    elb.elb_es
       | Lang_option _ | Lang_sugaroption _ -> 
-	  Auxl.error None "interal: option types not implemented in pp_induction\n"
+	  Auxl.error (Some r.rule_loc) "interal: option types not implemented in pp_induction\n"
       | Lang_nonterm (_,_) | Lang_metavar (_,_) | Lang_terminal _ -> false
     in List.exists element_uses_list_nt p.prod_es in
   (not r.rule_meta) && (List.exists uses_list_nt r.rule_ps)

--- a/src/defns.ml
+++ b/src/defns.ml
@@ -1233,7 +1233,6 @@ let process_raw_funclause
           let rhs = 
 	    match e with 
 	    | Ste_st(_,st) -> st 
-      (* TODO *)
 	    | _ -> Auxl.error (Some (Auxl.loc_of_symterm st)) "process_raw_funclause internal error - bad rhs" in
 (*       print_string ("lhs symterm: "^ Grammar_pp.pp_plain_symterm lhs ^ "\n");flush stdout;  *)
 (*       print_string ("rhs symterm: "^ Grammar_pp.pp_plain_symterm rhs ^ "\n");flush stdout;  *)

--- a/src/defns.ml
+++ b/src/defns.ml
@@ -1112,7 +1112,6 @@ let process_semiraw_rule (m: pp_mode) (xd: syntaxdefn) (lookup: made_parser)
               Grammar_parser.unfiltered_spec_el_list (Grammar_lexer.my_lexer true Grammar_lexer.filter) lexbuf
             with 
               Parsing.Parse_error  ->
-              (* TODO, Parse_error takes loc? *)
                 Auxl.error (Some l) ("unfiltered premise "^s^" cannot be parsed\n") in
             let collapsed_string = Auxl.collapse_embed_spec_el_list unfiltered_string in 
             (*let filtered_string = Embed_pp.pp_embed_spec m xd lookup collapsed_string in*)

--- a/src/defns.ml
+++ b/src/defns.ml
@@ -757,7 +757,7 @@ let fundefn_to_int_func (m:pp_mode) (xd:syntaxdefn) (deps:string list) (fd:funde
 	  match Auxl.hom_spec_for_hom_name "coq-struct" fd.fd_homs with
 	  | Some ([Hom_index i]) -> "{struct x" ^ string_of_int (i+1) ^ "} "
 	  | Some _ -> 
-	      Auxl.warning "malformed coq-struct homomorphism"; 
+     Auxl.warning (* TODO *) None "malformed coq-struct homomorphism"; 
 	      "{struct <<<malformed term in coq-struct hom>>>}"
 	  | None -> "" in
 
@@ -921,7 +921,8 @@ let pp_fundefnclass (m:pp_mode) (xd:syntaxdefn) lookup (fdc:fundefnclass) : stri
 	  ( match h with 
 	  | Some ([Hom_string s]) -> Some s
 	  | None -> None
-	  | _ -> Auxl.warning "malformed isa-proof/hol-proof hom"; Some "<<<malformed isa-proof/hol-proof hom>>>" ) in 
+   | _ -> Auxl.warning None  "malformed isa-proof/hol-proof hom"; Some "<<<malformed isa-proof/hol-proof hom>>>" ) in 
+(* TODO *)
 	( match m with
 	| Coq _ | Caml _ | Lem _ -> None
 	| Isa _ -> pp_proof (Auxl.hom_spec_for_hom_name "isa-proof" fdc.fdc_homs) 
@@ -935,7 +936,7 @@ let pp_fundefnclass (m:pp_mode) (xd:syntaxdefn) lookup (fdc:fundefnclass) : stri
       Auxl.print_with_comment m "\n" ("funs "^fdc.fdc_name) 
 	(Dependency.compute m xd int_funcs_collapsed)
 
-  | Twf _ -> Auxl.warning "internal: fundefnclass not implemented for Twelf"; ""
+  | Twf _ -> Auxl.warning None (*TODO*) "internal: fundefnclass not implemented for Twelf"; ""
   | Lex _ | Menhir _ -> ""
 
 
@@ -1241,7 +1242,7 @@ let process_raw_funclause
 
           { fc_lhs = lhs; fc_rhs = rhs; fc_loc = l }
       | _ -> 
-	  Auxl.warning ("process_raw_funclause lost symterm: "
+	Auxl.warning None (*TODO*) ("process_raw_funclause lost symterm: "
 			^ Grammar_pp.pp_plain_symterm st ^ "\n"); 
           let lhs = St_uninterpreted(l, "error") in
           let rhs = St_uninterpreted(l, Grammar_pp.pp_plain_symterm st) in 

--- a/src/defns.ml
+++ b/src/defns.ml
@@ -1141,9 +1141,9 @@ let process_semiraw_rule (m: pp_mode) (xd: syntaxdefn) (lookup: made_parser)
         let premises = List.map fancy_parse lss1 in
         let conclusion =
           match lss2 with
-          | [] -> raise (Rule_parse_error (l, "rule with no conclusion at "))
+          | [] -> raise (Rule_parse_error (l, "rule with no conclusion"))
           | [(l,s)] -> Term_parser.just_one_parse ~transform:(Term_parser.defn_transform prod_name) xd lookup rn_formula false l s
-          | _ -> raise (Rule_parse_error (l, "rule with multiple conclusions at "))
+          | _ -> raise (Rule_parse_error (l, "rule with multiple conclusions"))
         in
         let c = Term_parser.cd_env_of_syntaxdefn xd in
         let dr = {drule_name = defnclass_wrapper^defn_wrapper^annot.dla_name;

--- a/src/defns.ml
+++ b/src/defns.ml
@@ -511,7 +511,7 @@ let pp_defn fd (m:pp_mode) (xd:syntaxdefn) lookup (defnclass_wrapper:string) (un
         d.d_name
         (match mode with [Hom_string s] -> s
         (* TODO *)
-        | _ -> Auxl.error None ("rdx backend: cannot print mode for declaration: "^d.d_name))
+        | _ -> Auxl.error (Some d.d_loc) ("rdx backend: cannot print mode for declaration: "^d.d_name))
     with Not_found -> ());
     iter_sep (pp_processed_semiraw_rule fd m xd) "\n\n" d.d_rules
 
@@ -921,8 +921,7 @@ let pp_fundefnclass (m:pp_mode) (xd:syntaxdefn) lookup (fdc:fundefnclass) : stri
 	  ( match h with 
 	  | Some ([Hom_string s]) -> Some s
 	  | None -> None
-   | _ -> Auxl.warning None  "malformed isa-proof/hol-proof hom"; Some "<<<malformed isa-proof/hol-proof hom>>>" ) in 
-(* TODO *)
+   | _ -> Auxl.warning (Some fdc.fdc_loc)  "malformed isa-proof/hol-proof hom"; Some "<<<malformed isa-proof/hol-proof hom>>>" ) in 
 	( match m with
 	| Coq _ | Caml _ | Lem _ -> None
 	| Isa _ -> pp_proof (Auxl.hom_spec_for_hom_name "isa-proof" fdc.fdc_homs) 
@@ -936,7 +935,7 @@ let pp_fundefnclass (m:pp_mode) (xd:syntaxdefn) lookup (fdc:fundefnclass) : stri
       Auxl.print_with_comment m "\n" ("funs "^fdc.fdc_name) 
 	(Dependency.compute m xd int_funcs_collapsed)
 
-  | Twf _ -> Auxl.warning None (*TODO*) "internal: fundefnclass not implemented for Twelf"; ""
+  | Twf _ -> Auxl.warning (Some fdc.fdc_loc) "internal: fundefnclass not implemented for Twelf"; ""
   | Lex _ | Menhir _ -> ""
 
 
@@ -1114,7 +1113,7 @@ let process_semiraw_rule (m: pp_mode) (xd: syntaxdefn) (lookup: made_parser)
             with 
               Parsing.Parse_error  ->
               (* TODO, Parse_error takes loc? *)
-                Auxl.error None ("unfiltered premise "^s^" cannot be parsed\n") in
+                Auxl.error (Some l) ("unfiltered premise "^s^" cannot be parsed\n") in
             let collapsed_string = Auxl.collapse_embed_spec_el_list unfiltered_string in 
             (*let filtered_string = Embed_pp.pp_embed_spec m xd lookup collapsed_string in*)
             (* walk over collapsed_string, building a new string (with -ARG- replacing each [[.]]) and a list of symterms (one for each [[.]]) *)
@@ -1236,13 +1235,13 @@ let process_raw_funclause
 	    match e with 
 	    | Ste_st(_,st) -> st 
       (* TODO *)
-	    | _ -> Auxl.error None "process_raw_funclause internal error - bad rhs" in
+	    | _ -> Auxl.error (Some (Auxl.loc_of_symterm st)) "process_raw_funclause internal error - bad rhs" in
 (*       print_string ("lhs symterm: "^ Grammar_pp.pp_plain_symterm lhs ^ "\n");flush stdout;  *)
 (*       print_string ("rhs symterm: "^ Grammar_pp.pp_plain_symterm rhs ^ "\n");flush stdout;  *)
 
           { fc_lhs = lhs; fc_rhs = rhs; fc_loc = l }
       | _ -> 
-	Auxl.warning None (*TODO*) ("process_raw_funclause lost symterm: "
+	Auxl.warning (Some (loc_of_symterm st)) ("process_raw_funclause lost symterm: "
 			^ Grammar_pp.pp_plain_symterm st ^ "\n"); 
           let lhs = St_uninterpreted(l, "error") in
           let rhs = St_uninterpreted(l, Grammar_pp.pp_plain_symterm st) in 

--- a/src/defns.ml
+++ b/src/defns.ml
@@ -35,6 +35,7 @@
 
 open Types;;
 open Location;;
+open Auxl;;
 
 exception NotImplementedYet;;
 exception Rule_parse_error of loc * string
@@ -1038,7 +1039,7 @@ let process_semiraw_rule (m: pp_mode) (xd: syntaxdefn) (lookup: made_parser)
         |  Parsing.Parse_error | My_parse_error _ ->
             raise (Rule_parse_error (l, "bad annotation in \""^s^"\" "))
         |  e ->
-            (print_string ("exception in parsing \""^s^"\" at "^Location.pp_loc l^"\n");
+            (report_error (Some l) ("exception in parsing \""^s^"\\n");
              flush stdout;
              raise e) in
         (* let categories = List.map del c in *)

--- a/src/defns.mli
+++ b/src/defns.mli
@@ -31,7 +31,11 @@
 (*  IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                         *)
 (**************************************************************************)
 
-exception Rule_parse_error of string
+
+open Types;;
+open Location;;
+
+exception Rule_parse_error of loc * string
 val pp_fun_or_reln_defnclass :
   out_channel ->
   Types.pp_mode ->

--- a/src/dependency.ml
+++ b/src/dependency.ml
@@ -216,7 +216,7 @@ let sort (l : ('b * 'b list * 'a) list) : ('b * 'a) list list * 'b list =
       List.assoc n (List.map (fun (x,y) -> (y,x)) !info) 
     with Not_found -> 
       (* Auxl.error ("internal: sort: cannot find a node labelled " ^ n ^ "\n") *) 
-      Auxl.warning ("internal: sort: cannot find a node labelled " ^ n ^ "\n");
+      Auxl.warning None ("internal: sort: cannot find a node labelled " ^ n ^ "\n");
       raise Not_found in
 
   let add_vertex g i c v =

--- a/src/dependency.ml
+++ b/src/dependency.ml
@@ -231,7 +231,7 @@ let sort (l : ('b * 'b list * 'a) list) : ('b * 'a) list list * 'b list =
       let tnv = find_vertex tn g_vertex_info in
       if (not (G.mem_edge g snv tnv)) then G.add_edge g snv tnv 
     with Not_found -> 
-      Auxl.warning ("internal: sort: cannot connect " ^ sn ^ " to " ^ tn ^"\n") in
+      Auxl.warning None ("internal: sort: cannot connect " ^ sn ^ " to " ^ tn ^"\n") in
   
   (* adding vertexes *)
   let vl = List.map (function (x,_,_) -> x) l in
@@ -310,7 +310,7 @@ let isa_primrec_collapse m xd (funcs:int_funcs) : int_funcs_collapsed =
   let collapse_clause m id (_, lhs, rhs) =
     match m with
     | Isa _ -> "\"" ^ id ^ " " ^ lhs ^ " = (" ^ rhs ^ ")\"\n"
-    | _ -> Auxl.error "internal: isa_collapse called with wrong target\n" in
+    | _ -> Auxl.error None "internal: isa_collapse called with wrong target\n" in
 
   let collapse_clauses m id clauses =
     String.concat "| " (List.map (collapse_clause m id) clauses) in
@@ -341,19 +341,19 @@ let isa_primrec_collapse m xd (funcs:int_funcs) : int_funcs_collapsed =
       let rx_inp_type = Str.regexp ".*\"\\(.*\\) =>.*" in
       if Str.string_match rx_inp_type header 0 
       then Str.matched_group 1 header 
-      else Auxl.error "internal: cannot extract the inp type from the header\n" in
+      else Auxl.error None "internal: cannot extract the inp type from the header\n" in
     let (inp_type,inp_type_list) =
       ( match List.map (fun x -> extract_inp_type x.r_fun_header) g with
       | h::t -> (h,t)
       | _ -> raise Auxl.ThisCannotHappen ) in
     if not (List.for_all (fun t -> String.compare inp_type t = 0) inp_type_list) 
-    then Auxl.error "internal: collapsing functions over different types\n";
+    then Auxl.error None "internal: collapsing functions over different types\n";
 
     let extract_ret_type (header,_,_) =
       let rx_ret_type = Str.regexp ".*=> \\(.*\\)\"" in
       if Str.string_match rx_ret_type header 0 
       then Str.matched_group 1 header 
-      else Auxl.error "internal: cannot extract the out type from the header\n" in
+      else Auxl.error None "internal: cannot extract the out type from the header\n" in
     let ret_types = List.map (fun x -> extract_ret_type x.r_fun_header) g in
    
     let output_type =
@@ -373,7 +373,7 @@ let isa_primrec_collapse m xd (funcs:int_funcs) : int_funcs_collapsed =
     let compare_lhs l1 l2 =
       List.for_all2 (fun lc1 lc2 -> String.compare lc1 lc2 = 0) l1 l2 in
     if not (List.for_all (fun f -> compare_lhs lhs (extract_lhs f)) (List.tl g))
-    then Auxl.error "internal: non equal lhs when collapsing";
+    then Auxl.error None "internal: non equal lhs when collapsing";
 
     (* 5- the rhs *)
     let extract_rhs f =
@@ -576,13 +576,13 @@ let collapse m xd (funcs:int_funcs) : int_funcs_collapsed =
   | Coq _ -> coq_collapse m xd funcs
   | Twf _ -> twf_collapse m xd funcs
   | Caml _ -> caml_collapse m xd funcs
-  | Tex _ | Ascii _ -> Auxl.error "internal: collapse of Tex-Ascii\n"
+  | Tex _ | Ascii _ -> Auxl.error None "internal: collapse of Tex-Ascii\n"
 
 (* *** the printer *)
 
 let print m xd (sorting,refl) =
   match m with
-  | Tex _ | Ascii _ -> Auxl.error "internal: print of Tex-Ascii\n"
+  | Tex _ | Ascii _ -> Auxl.error None "internal: print of Tex-Ascii\n"
   | Isa io ->
       let print_lemma block = 
 	if ( List.exists 

--- a/src/grammar_lexer.mll
+++ b/src/grammar_lexer.mll
@@ -47,6 +47,10 @@ open Grammar_parser
 exception Eof
 exception CannotHappen
 
+let mkloc p = 
+  [ { Location.loc_start = p;  
+        Location.loc_end = p } ]
+
 let incr_linenum lexbuf =
   let pos = lexbuf.Lexing.lex_curr_p in
   lexbuf.Lexing.lex_curr_p <- 
@@ -162,9 +166,12 @@ let my_lexer : bool -> lexer -> lexer =
             next_token ()
         with
           ex -> 
-            (print_string ("Lexing error at "^pp_position2 lexbuf.Lexing.lex_curr_p^"\n");
-             flush stdout;
-             raise ex)
+            (* TODO call error here *)
+            let loc = mkloc lexbuf.Lexing.lex_curr_p in
+            (error (Some loc) ("Lexing error");
+             (* flush stdout;
+             raise ex *)
+             )
           
 let trim : string -> string =
   fun s ->
@@ -463,10 +470,13 @@ and comments surrounding_lexer level = parse
   | _     
       { comments surrounding_lexer level lexbuf }
   | eof     
-      { warning ("open comment at "
-		 ^ pp_position2 
-		     (match level with p::ps->p | []->raise CannotHappen)
-		 ^ " is not closed");
+      { let 
+          loc = 
+            match level with 
+              | p::ps -> mkloc p
+              | [] -> raise CannotHappen 
+        in 
+          warning None ("open comment is not closed ");
 	raise End_of_file }
 
 and linecomment surrounding_lexer = parse

--- a/src/grammar_lexer.mll
+++ b/src/grammar_lexer.mll
@@ -166,11 +166,8 @@ let my_lexer : bool -> lexer -> lexer =
             next_token ()
         with
           ex -> 
-            (* TODO call error here *)
             let loc = mkloc lexbuf.Lexing.lex_curr_p in
             (error (Some loc) ("Lexing error");
-             (* flush stdout;
-             raise ex *)
              )
           
 let trim : string -> string =

--- a/src/grammar_parser.mly
+++ b/src/grammar_parser.mly
@@ -52,8 +52,8 @@ let mkp () =
 (*   {desc=x; loc=l} *)
     
 let parse_error s = 
-  raise (My_parse_error (Some (mkl ()), "Parse error: " ^ s ^ " " 
-	   ^ Location.pp_position2 (Parsing.symbol_end_pos () )))
+  raise (My_parse_error (Some (mkl ()), "Parse error: " ^ s 
+	    ))
 
 (* %token EQUAL             *)
 %}

--- a/src/grammar_parser.mly
+++ b/src/grammar_parser.mly
@@ -52,7 +52,7 @@ let mkp () =
 (*   {desc=x; loc=l} *)
     
 let parse_error s = 
-  raise (My_parse_error ("Parse error: " ^ s ^ " " 
+  raise (My_parse_error (Some (mkl ()), "Parse error: " ^ s ^ " " 
 	   ^ Location.pp_position2 (Parsing.symbol_end_pos () )))
 
 (* %token EQUAL             *)

--- a/src/grammar_pp.ml
+++ b/src/grammar_pp.ml
@@ -1680,15 +1680,15 @@ and pp_plain_dotenv3 de3 =
 
 and pp_plain_bindspec bs =
   match bs with
-  | Bind (mse, nonterm) -> "Bind ("^pp_plain_mse mse^", "^pp_plain_nonterm nonterm^")"
-  | AuxFnDef (f,mse) -> "AuxFnDef ("^f^", "^pp_plain_mse mse^")"
-  | NamesEqual (_,_) -> "NamesEqual"
-  | NamesDistinct (_,_) -> "NamesDistinct"
+  | Bind (loc, mse, nonterm) -> "Bind ("^pp_plain_mse mse^", "^pp_plain_nonterm nonterm^")"
+  | AuxFnDef (loc, f,mse) -> "AuxFnDef ("^f^", "^pp_plain_mse mse^")"
+  | NamesEqual (loc,_,_) -> "NamesEqual"
+  | NamesDistinct (loc,_,_) -> "NamesDistinct"
   | AllNamesDistinct _ -> "AllNamesDistinct"
 
 and pp_bindspec m xd sie de bs = 
   match bs with
-  | Bind (mse,nt) -> 
+  | Bind (loc,mse,nt) -> 
       ( match m with 
       | Ascii ao -> 
           pp_BIND^" " ^  pp_mse_string m xd sie de mse ^ " " 
@@ -1697,12 +1697,12 @@ and pp_bindspec m xd sie de bs =
           pp_tex_BIND ^ "\\; " ^  pp_mse_string m xd sie de mse ^ "\\; "
 	  ^ pp_tex_IN ^ "\\; " ^ pp_nonterm m xd nt
       | Coq _ | Isa _ | Hol _ | Lem _ | Twf _ | Caml _ | Lex _ | Menhir _ -> raise ThisCannotHappen )
-  | AuxFnDef (f,mse) -> 
+  | AuxFnDef (loc,f,mse) -> 
       ( match m with 
       | Ascii ao -> pp_auxfn m xd f ^ "" ^ pp_EQ ^ "" ^ pp_mse_string m xd sie de mse
       | Tex xo -> pp_auxfn m xd f ^ "" ^ pp_tex_EQ ^ "" ^ pp_mse_string m xd sie de mse
       | Coq _ | Isa _ | Hol _ | Lem _ | Twf _ | Caml _ | Lex _ | Menhir _ -> raise ThisCannotHappen )
-  | NamesEqual (mse,mse') -> 
+  | NamesEqual (loc,mse,mse') -> 
       ( match m with 
       | Ascii ao -> 
           pp_NAMES ^ "" ^ pp_LPAREN ^ "" ^ pp_mse_string m xd sie de mse ^ "" ^ pp_RPAREN 
@@ -1713,7 +1713,7 @@ and pp_bindspec m xd sie de bs =
 	  ^ "" ^ pp_tex_RPAREN ^ "\\," ^ pp_tex_EQ ^ "\\," ^ pp_tex_NAMES
 	  ^ "" ^ pp_tex_LPAREN ^ "" ^ pp_mse_string m xd sie de mse' ^ "" ^ pp_tex_RPAREN
       | Coq _ | Isa _ | Hol _ | Lem _ | Twf _ | Caml _ | Lex _ | Menhir _ -> raise ThisCannotHappen )
-  | NamesDistinct (mse,mse') -> 
+  | NamesDistinct (loc,mse,mse') -> 
       ( match m with 
       | Ascii ao -> 
           pp_NAMES ^ "" ^ pp_LPAREN ^ "" ^ pp_mse_string m xd sie de mse ^ "" ^ pp_RPAREN
@@ -1725,7 +1725,7 @@ and pp_bindspec m xd sie de bs =
 	  ^ pp_tex_NAMES ^ "" ^ pp_tex_LPAREN ^ "" ^ pp_mse_string m xd sie de mse' 
 	  ^ ""^pp_tex_RPAREN
       | Coq _ | Isa _ | Hol _ | Lem _ | Twf _ | Caml _ | Lex _ | Menhir _ -> raise ThisCannotHappen )
-  | AllNamesDistinct mse -> 
+  | AllNamesDistinct (loc,mse) -> 
       ( match m with 
       | Ascii ao -> 
           pp_DISTINCTNAMES ^ "" ^ pp_LPAREN ^ "" ^ pp_mse_string m xd sie de mse 
@@ -2400,7 +2400,7 @@ and pp_nominal_prod m xd rnn rpw p =
   let rec arrange np bs =
     match bs with
     | [] -> np
-    | (Bind (MetaVarExp mv, nt)) :: bst ->
+    | (Bind (loc, MetaVarExp mv, nt)) :: bst ->
 	let rnp =
 	  Auxl.option_map
 	    ( fun (bl,el) ->

--- a/src/grammar_pp.ml
+++ b/src/grammar_pp.ml
@@ -323,7 +323,7 @@ and pp_raw_dots n =
   | 0 -> pp_DOTDOT 
   | 1 -> pp_DOTDOTDOT
   | 2 -> pp_DOTDOTDOTDOT 
-  | _ -> Auxl.error "internal: >2 in pp_raw_dots"
+  | _ -> Auxl.error None "internal: >2 in pp_raw_dots"
 
 and pp_raw_prod p = 
   pad 60 ((match p.raw_prod_flavour with Bar -> pp_BAR)    
@@ -757,7 +757,7 @@ let pp_tex_DOTDOTDOTDOT       = "...."
 let pp_tex_NAME_PREFIX m       = 
   match m with
   | Tex xo -> xo.ppt_name_prefix
-  |  _ -> Auxl.error "internal: pp_tex_NAME_PREFIX"
+  |  _ -> Auxl.error None "internal: pp_tex_NAME_PREFIX"
 
 let pp_tex_METAVARS_NAME m     = "\\"^pp_tex_NAME_PREFIX m^"metavars"
 let pp_tex_RULES_NAME m        = "\\"^pp_tex_NAME_PREFIX m^"grammar"
@@ -1246,7 +1246,8 @@ and coq_maybe_decide_equality m xd homs ntmvr =
       ^ ( match eh with
         | [ ] -> "  decide equality; auto with ott_coq_equality arith."
         | [ Hom_string s ] -> s 
-        | _ -> Auxl.error "malformed coq-equality homomorphism\n" )
+        (* TODO *)
+        | _ -> Auxl.error None "malformed coq-equality homomorphism\n" )
       ^ "\nDefined.\n"
       ^ "Hint Resolve eq_" ^ type_name  ^ " : ott_coq_equality.\n"
 
@@ -3169,7 +3170,7 @@ and extract_nonterms s =
 
 and pp_symterm_node_body_fancy_formula m xd sie de stnb : string =
   (* pull out the real symterm list *)
-  let sts = Auxl.option_map (function ste -> match ste with Ste_st(_,st) -> Some st | _ -> Auxl.error "internal: non Ste_st found in pp_symterm_node_body_fancy_formula") stnb.st_es in
+  let sts = Auxl.option_map (function ste -> match ste with Ste_st(_,st) -> Some st | _ -> Auxl.error None "internal: non Ste_st found in pp_symterm_node_body_fancy_formula") stnb.st_es in
   let pp_sts = List.map (pp_symterm m xd sie de) sts in
   let strings = Str.full_split (Str.regexp_string "-ARG-") stnb.st_prod_name in
   let pp_string s = match m with
@@ -3191,7 +3192,7 @@ and pp_symterm_node_body m xd sie de stnb : string =
     try
       let ntrt,pps = List.assoc stnb.st_rule_ntr_name xd.xd_srd.srd_subrule_pn_promotion in
       try List.assoc stnb.st_prod_name pps with
-        Not_found -> Auxl.error ("internal error: pp_symterm_node_body \""^stnb.st_prod_name^"\" Not_found in pps "^pp_plain_pps pps)
+        Not_found -> Auxl.error None ("internal error: pp_symterm_node_body \""^stnb.st_prod_name^"\" Not_found in pps "^pp_plain_pps pps)
     with
       Not_found -> stnb.st_prod_name in 
   let p = Auxl.prod_of_prodname xd promoted_pn in
@@ -3248,7 +3249,7 @@ and pp_symterm_node_body m xd sie de stnb : string =
                       | Lem lo -> 
                           pp_symterm_element_judge_lem_plain m xd sie de p'' stnb''
                       | Ascii _ | Tex _ | Lex _ | Menhir _ -> raise ThisCannotHappen
-                      | Caml _ -> Auxl.error "internal: Caml pp_symterm for proper symterms not supported"
+                      | Caml _ -> Auxl.error None "internal: Caml pp_symterm for proper symterms not supported"
                       )
                   | _ -> raise (Invalid_argument ("pp_symterm_node_body2: strange production in formula_judgement")))
               | _ -> raise (Invalid_argument ("pp_symterm_node_body3: strange production in formula judgement ")))
@@ -3268,7 +3269,7 @@ and pp_symterm_node_body m xd sie de stnb : string =
 	     
               (match m with
               | Ascii _ | Tex _ | Lex _ | Menhir _ -> Auxl.errorm m "formula_dots"
-              | Caml _ -> Auxl.error "internal: Caml pp_symterm for proper symterms not supported"
+              | Caml _ -> Auxl.error None "internal: Caml pp_symterm for proper symterms not supported"
               | Isa io ->
                   (match isa_fancy_syntax_hom_for_prod m xd io p with
                   | None -> 
@@ -4263,8 +4264,8 @@ and make_name_element m xd typ e =
   match e with
   | Ste_st (_,st) -> make_name_symterm m xd typ st 
   | Ste_metavar (_,mvr,_) -> if typ then pp_metavarroot_ty m xd mvr else pp_metavarroot m xd mvr
-  | Ste_var (_,mvr,_) -> (* mvr *) Auxl.error "internal: Ste_var in make_name_element"
-  | Ste_list (_,stlil) -> Auxl.error "internal: Ste_list in make_name_element"
+  | Ste_var (_,mvr,_) -> (* mvr *) Auxl.error None "internal: Ste_var in make_name_element"
+  | Ste_list (_,stlil) -> Auxl.error None "internal: Ste_list in make_name_element"
 and make_name_elements m xd typ es = 
   let sep = if typ then "*" else "_" in
   let lst = List.map (make_name_element m xd typ) es in
@@ -4285,7 +4286,7 @@ and make_dep_element e =
   | Ste_st (_,st) -> make_dep_symterm st
   | Ste_metavar (_,mvr,_) -> [ mvr ]
   | Ste_var (_,mvr,_) -> [ mvr ]
-  | Ste_list (_,stlil) -> Auxl.error "internal: Ste_list in make_dep_element"
+  | Ste_list (_,stlil) -> Auxl.error None "internal: Ste_list in make_dep_element"
 and make_dep_elements es = 
   List.concat (List.map make_dep_element es) 
 

--- a/src/grammar_pp.ml
+++ b/src/grammar_pp.ml
@@ -1318,6 +1318,7 @@ and pp_metavardefn m xd mvd =
 	| Ascii _ | Tex _ -> raise Auxl.ThisCannotHappen ))
 
 and pp_metavarrep m xd mvd_rep type_name =
+  (* TODO report locations for these warnings? *)
   match m with
   | Ascii ao ->
       pp_homomorphism_list m xd mvd_rep
@@ -1327,37 +1328,37 @@ and pp_metavarrep m xd mvd_rep type_name =
       ( try
 	let hs = List.assoc "isa" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning ("undefined isa metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning None ("undefined isa metavarrep for "^type_name^"\n"); "UNDEFINED" )
   | Hol ho ->
       ( try
 	let hs = List.assoc "hol" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning ("undefined hol metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning None ("undefined hol metavarrep for "^type_name^"\n"); "UNDEFINED" )
   | Lem lo ->
       ( try
 	let hs = List.assoc "lem" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning ("undefined lem metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning None ("undefined lem metavarrep for "^type_name^"\n"); "UNDEFINED" )
   | Coq co ->
       ( try
 	let hs = List.assoc "coq" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning ("undefined coq metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning None ("undefined coq metavarrep for "^type_name^"\n"); "UNDEFINED" )
   | Rdx ro ->
       ( try
 	let hs = List.assoc "rdx" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning ("undefined rdx metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning None ("undefined rdx metavarrep for "^type_name^"\n"); "UNDEFINED" )
   | Twf wo ->
       ( try
 	let hs = List.assoc "twf" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning ("undefined Twelf metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning None ("undefined Twelf metavarrep for "^type_name^"\n"); "UNDEFINED" )
   | Caml oo ->
       ( try
 	let hs = List.assoc "ocaml" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning ("undefined OCaml metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning None ("undefined OCaml metavarrep for "^type_name^"\n"); "UNDEFINED" )
 	
 and pp_prodname m xd pn =  (* FZ this is never called *)
   match m with
@@ -3115,7 +3116,6 @@ and pp_symterm m xd sie de st : string =
           ^ (if xo.ppt_colour then "}" else "")
           ^ "}"
       | _ ->
-      
           Printf.sprintf "(PARSE_ERROR \"%s\" \"%s\")"
             (Location.pp_loc l) (String.escaped s)
 
@@ -3141,7 +3141,8 @@ and extract_nonterms_deep_ste_list slil =
   | [] -> []
   | Stli_single (_,stel)::tl -> (extract_nonterms_deep stel) @ (extract_nonterms_deep_ste_list tl)
   | Stli_listform _::tl -> 
-      Auxl.warning "<<internal: extract_nonterms_deep_ste_list not implemented over listforms>>>";
+      (* TODO location? *)
+      Auxl.warning None "<<internal: extract_nonterms_deep_ste_list not implemented over listforms>>>";
       extract_nonterms_deep_ste_list tl )
   
 and extract_nonterms_deep s =
@@ -3153,7 +3154,8 @@ and extract_nonterms_deep s =
   | (Ste_st (_,St_node (_,stnb)))::t -> (extract_nonterms_deep stnb.st_es) @ (extract_nonterms_deep t)
   | (Ste_list (_,slil))::t -> (extract_nonterms_deep_ste_list slil) @ (extract_nonterms_deep t)
   | h::t ->
-      Auxl.warning
+      (* TODO *)
+      Auxl.warning None
         ("internal: extract_nonterms_deep case failure\n "
          ^ (pp_plain_symterm_element h) ^ "\n\n"); (extract_nonterms_deep t)
 
@@ -3165,7 +3167,8 @@ and extract_nonterms s =
   | (Ste_st (_,St_node (_,stnb)))::t -> (stnb.st_rule_ntr_name,[]) :: (extract_nonterms t)
   (* | (Ste_st (_,St_node (_,stnb)))::t -> (extract_nonterms stnb.st_es) @ (extract_nonterms t)  *)
   | h::t ->
-      Auxl.warning
+      (* TODO *)
+      Auxl.warning None
         ("internal: extract_nonterms case failure\n "
          ^ (pp_plain_symterm_element h) ^ "\n\n"); (extract_nonterms t)
 
@@ -3699,7 +3702,7 @@ and pp_symterm_list_items m xd sie (de :dotenv) tmopt prod_es stlis : (string * 
       | (Lang_nonterm(ntr,_))::t -> ntr :: (intern t)
       | (Lang_metavar(mvr,_))::t -> mvr :: (intern t)
       | (Lang_terminal _)::t -> intern t
-      | _::t -> Auxl.warning "internal: elements_to_string never happen\n"; intern t )
+      | _::t -> Auxl.warning None "internal: elements_to_string never happen\n"; intern t )
     in (* List.rev *) (intern ls) in
 
   let include_terminals = 
@@ -3800,7 +3803,7 @@ and pp_symterm_list_item m xd sie (de :dotenv) tmopt include_terminals prod_es s
       | (Lang_nonterm(ntr,_))::t -> ntr :: (intern t)
       | (Lang_metavar(mvr,_))::t -> mvr :: (intern t)
       | (Lang_terminal _)::t -> intern t
-      | _::t -> Auxl.warning "internal: elements_to_string never happen\n"; intern t )
+      | _::t -> Auxl.warning None "internal: elements_to_string never happen\n"; intern t )
     in (* List.rev *) (intern ls) in
 
   match stli with
@@ -3993,7 +3996,7 @@ and pp_symterm_list_body m xd sie (de :dotenv) tmopt include_terminals prod_es s
                     (Auxl.promote_ntr xd ntr,b) :: (intern t)
                 | (Lang_metavar(mvr,_))::t -> (mvr,false) :: (intern t)
                 | (Lang_terminal _)::t -> intern t
-                | _::t -> Auxl.warning "internal: elements_to_string never happen\n"; intern t )
+                | _::t -> Auxl.warning None "internal: elements_to_string never happen\n"; intern t )
               in (* List.rev *) (intern ls) in
 
 	    let ty_list = Str.split (Str.regexp "(\\|*\\|)") de1i.de1_coq_type_of_pattern in

--- a/src/grammar_pp.ml
+++ b/src/grammar_pp.ml
@@ -1246,7 +1246,6 @@ and coq_maybe_decide_equality m xd homs ntmvr loc =
       ^ ( match eh with
         | [ ] -> "  decide equality; auto with ott_coq_equality arith."
         | [ Hom_string s ] -> s 
-        (* TODO *)
         | _ -> Auxl.error (Some loc) "malformed coq-equality homomorphism\n" )
       ^ "\nDefined.\n"
       ^ "Hint Resolve eq_" ^ type_name  ^ " : ott_coq_equality.\n"
@@ -1260,7 +1259,7 @@ and pp_metavardefn m xd mvd =
                                (function (mvr,homs)->pp_metavarroot m xd mvr)
                                mvd.mvd_names)) 
       ^ " " ^ pp_CCE ^ " " 
-      ^ pp_metavarrep m xd mvd.mvd_rep "" ^ "\n"
+      ^ pp_metavarrep m xd mvd.mvd_rep ("" ^ "\n") mvd.mvd_loc
   | Tex xo -> 
       " $ "
       ^ (String.concat " ,\\, "(List.map 
@@ -1274,7 +1273,7 @@ and pp_metavardefn m xd mvd =
 	| Coq co ->
 	    let type_name = pp_metavarroot_ty m xd mvd.mvd_name in
 	    "Definition " ^  type_name ^ " := " 
-	    ^ pp_metavarrep m xd mvd.mvd_rep type_name ^ "." ^ pp_com ^ "\n"
+	    ^ pp_metavarrep m xd mvd.mvd_rep (type_name ^ "." ^ pp_com ^ "\n") mvd.mvd_loc
 	    ^ coq_maybe_decide_equality m xd mvd.mvd_rep (Mvr mvd.mvd_name) mvd.mvd_loc
 	| Rdx ro -> ""
 	    (* let type_name = pp_metavarroot_ty m xd mvd.mvd_name in *)
@@ -1285,7 +1284,7 @@ and pp_metavardefn m xd mvd =
 	    "type "
 	    ^ type_name 
 	    ^ " = " 
-	    ^ pp_metavarrep m xd mvd.mvd_rep type_name
+	    ^ pp_metavarrep m xd mvd.mvd_rep type_name mvd.mvd_loc
 	    ^ pp_com ^ "\n"
 	| Isa io ->
 	    let type_name = pp_metavarroot_ty m xd mvd.mvd_name in 
@@ -1294,20 +1293,20 @@ and pp_metavardefn m xd mvd =
 	      "atom_decl \"" ^ type_name ^ "\"" ^ pp_com ^ "\n"
 	    else
 	      "type_synonym \"" ^ type_name ^ "\" = \"" 
-	      ^ pp_metavarrep m xd mvd.mvd_rep type_name^ "\"" ^ pp_com ^ "\n"
+	      ^ pp_metavarrep m xd mvd.mvd_rep (type_name^ "\"" ^ pp_com ^ "\n") mvd.mvd_loc
 	| Hol ho -> 
 	    let type_name = pp_metavarroot_ty m xd mvd.mvd_name in 
 	    "val _ = type_abbrev(\""
 	    ^ type_name
 	    ^ "\", ``:"
-	    ^ pp_metavarrep m xd mvd.mvd_rep type_name ^ "``);"
+	    ^ pp_metavarrep m xd mvd.mvd_rep (type_name ^ "``);") mvd.mvd_loc
 	    ^ pp_com ^ "\n"
 	| Lem lo -> 
 	    let type_name = pp_metavarroot_ty m xd mvd.mvd_name in 
 	    "type "
 	    ^ type_name
 	    ^ " = "
-	    ^ pp_metavarrep m xd mvd.mvd_rep type_name
+	    ^ pp_metavarrep m xd mvd.mvd_rep type_name mvd.mvd_loc
 	    ^ pp_com ^ "\n"
 	| Twf _ -> 
 	    "%abbrev "
@@ -1317,8 +1316,7 @@ and pp_metavardefn m xd mvd =
         | Menhir _ -> ""
 	| Ascii _ | Tex _ -> raise Auxl.ThisCannotHappen ))
 
-and pp_metavarrep m xd mvd_rep type_name =
-  (* TODO report locations for these warnings? *)
+and pp_metavarrep m xd mvd_rep type_name loc =
   match m with
   | Ascii ao ->
       pp_homomorphism_list m xd mvd_rep
@@ -1328,37 +1326,37 @@ and pp_metavarrep m xd mvd_rep type_name =
       ( try
 	let hs = List.assoc "isa" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning None ("undefined isa metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning (Some loc) ("undefined isa metavarrep for "^type_name^"\n"); "UNDEFINED" )
   | Hol ho ->
       ( try
 	let hs = List.assoc "hol" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning None ("undefined hol metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning (Some loc) ("undefined hol metavarrep for "^type_name^"\n"); "UNDEFINED" )
   | Lem lo ->
       ( try
 	let hs = List.assoc "lem" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning None ("undefined lem metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning (Some loc) ("undefined lem metavarrep for "^type_name^"\n"); "UNDEFINED" )
   | Coq co ->
       ( try
 	let hs = List.assoc "coq" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning None ("undefined coq metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning (Some loc) ("undefined coq metavarrep for "^type_name^"\n"); "UNDEFINED" )
   | Rdx ro ->
       ( try
 	let hs = List.assoc "rdx" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning None ("undefined rdx metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning (Some loc) ("undefined rdx metavarrep for "^type_name^"\n"); "UNDEFINED" )
   | Twf wo ->
       ( try
 	let hs = List.assoc "twf" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning None ("undefined Twelf metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning (Some loc) ("undefined Twelf metavarrep for "^type_name^"\n"); "UNDEFINED" )
   | Caml oo ->
       ( try
 	let hs = List.assoc "ocaml" mvd_rep in
 	pp_hom_spec m xd hs
-      with Not_found -> Auxl.warning None ("undefined OCaml metavarrep for "^type_name^"\n"); "UNDEFINED" )
+      with Not_found -> Auxl.warning (Some loc) ("undefined OCaml metavarrep for "^type_name^"\n"); "UNDEFINED" )
 	
 and pp_prodname m xd pn =  (* FZ this is never called *)
   match m with
@@ -3141,7 +3139,6 @@ and extract_nonterms_deep_ste_list slil =
   | [] -> []
   | Stli_single (_,stel)::tl -> (extract_nonterms_deep stel) @ (extract_nonterms_deep_ste_list tl)
   | Stli_listform hd::tl -> 
-      (* TODO location? *)
       Auxl.warning (Some hd.stl_loc) "<<internal: extract_nonterms_deep_ste_list not implemented over listforms>>>";
       extract_nonterms_deep_ste_list tl )
   
@@ -3154,7 +3151,6 @@ and extract_nonterms_deep s =
   | (Ste_st (_,St_node (_,stnb)))::t -> (extract_nonterms_deep stnb.st_es) @ (extract_nonterms_deep t)
   | (Ste_list (_,slil))::t -> (extract_nonterms_deep_ste_list slil) @ (extract_nonterms_deep t)
   | h::t ->
-      (* TODO *)
       Auxl.warning (Some (Auxl.loc_of_symterm_element h))
         ("internal: extract_nonterms_deep case failure\n "
          ^ (pp_plain_symterm_element h) ^ "\n\n"); (extract_nonterms_deep t)
@@ -3167,7 +3163,6 @@ and extract_nonterms s =
   | (Ste_st (_,St_node (_,stnb)))::t -> (stnb.st_rule_ntr_name,[]) :: (extract_nonterms t)
   (* | (Ste_st (_,St_node (_,stnb)))::t -> (extract_nonterms stnb.st_es) @ (extract_nonterms t)  *)
   | h::t ->
-      (* TODO *)
       Auxl.warning (Some (Auxl.loc_of_symterm_element h))
         ("internal: extract_nonterms case failure\n "
          ^ (pp_plain_symterm_element h) ^ "\n\n"); (extract_nonterms t)

--- a/src/grammar_pp.ml
+++ b/src/grammar_pp.ml
@@ -3115,6 +3115,7 @@ and pp_symterm m xd sie de st : string =
           ^ (if xo.ppt_colour then "}" else "")
           ^ "}"
       | _ ->
+      
           Printf.sprintf "(PARSE_ERROR \"%s\" \"%s\")"
             (Location.pp_loc l) (String.escaped s)
 

--- a/src/grammar_typecheck.ml
+++ b/src/grammar_typecheck.ml
@@ -2075,7 +2075,7 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
     | (pn,l)::pnls' -> 
         (try 
           let l' = List.assoc pn pnls' in
-          ty_error ("production name \""^pn^"\" is used for multiple productions, at "^Location.pp_loc l^" and "^Location.pp_loc l') ""
+          ty_error2 (l@l') ("production name \""^pn^"\" is used for multiple productions, at "^Location.pp_loc l^" and "^Location.pp_loc l') ""
         with Not_found ->
           find_first_duplicate2 pnls')
     | [] -> () in

--- a/src/grammar_typecheck.ml
+++ b/src/grammar_typecheck.ml
@@ -390,7 +390,7 @@ let subrule (xd:syntaxdefn) (include_meta_prods:bool)
       | [pu] -> (pl.prod_name,pu.prod_name)
       | pu::pu'::pus' -> 
           (* TIDI get loc *)
-          Auxl.warning  None
+          Auxl.warning  (Some pl.prod_loc)
             ("production \""^pl.prod_name^"\" is a subproduction of more than one production: "^String.concat ", " (List.map (function pu -> "\""^pu.prod_name^"\"") pus) ^" (taking the first)\n");
           (pl.prod_name,pu.prod_name)
     )

--- a/src/grammar_typecheck.ml
+++ b/src/grammar_typecheck.ml
@@ -1119,7 +1119,7 @@ and cd_element c (e:raw_element) : semiraw_element =
                   elb_es = es' } in
       Sr_el(Lang_list elb)
   | (Raw_sugaroption (_, _)|Raw_nelist (_, _)|Raw_list (_, _)|Raw_option (_, _))
-      -> Auxl.error None "internal: sugaroption, nelist, list and option not supported"
+      -> Auxl.error (Some (Auxl.loc_of_raw_element e))  "internal: sugaroption, nelist, list and option not supported"
 
 and cd_comp_bound : cd_env -> raw_comp_bound -> bound * metavarroot
     = fun c rcb -> match rcb with

--- a/src/grammar_typecheck.ml
+++ b/src/grammar_typecheck.ml
@@ -2494,7 +2494,6 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
      right type right now, but later when a parser has been constructed. *)
 
 
-  (*TODO get loc*)
   let rec count_holes_element prod (el:element) : int =
     match el with
     | Lang_nonterm _ -> 0

--- a/src/grammar_typecheck.ml
+++ b/src/grammar_typecheck.ml
@@ -2590,7 +2590,7 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
     List.iter (fun ntr1 -> let idx1 = vertex_of_ntr ntr1 in 
     List.iter (fun ntr2 ->
       if ntr2 = ntr1 then
-        ty_error ("non-terminal " ^ ntr1 ^ " has a non-productive self-loop.") ""
+        ty_error2 (Auxl.loc_of_ntr xd ntr1) ("non-terminal " ^ ntr1 ^ " has a non-productive self-loop.") ""
       else
         G.add_edge g idx1 (vertex_of_ntr ntr2))
       tos)
@@ -2628,7 +2628,8 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
   let (scc_vertex_sets : G.V.t list list) = G.Components.scc_list g in
   List.iter (fun x ->
                if List.length x > 1 then
-                 ty_error ("There is a non-productive cycle among the following non-terminals: " ^ ntrs_to_string x) ""
+                 ty_error2 (Auxl.loc_of_ntr xd (ntr_of_vertex (List.hd x)))
+                   ("There is a non-productive cycle among the following non-terminals: " ^ ntrs_to_string x) ""
                else
                  ())
             scc_vertex_sets;
@@ -2653,7 +2654,7 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
     else 
       ( match Auxl.find_first_duplicate2 (fun (_,s1) -> fun (_,s2) -> (compare s1 s2) = 0 ) (List.rev candidate) with
       | None -> candidate 
-      | Some s -> ty_error ("duplicated subrule: "^(Auxl.dump_structure_entry s)) "" ) in
+      | Some s -> ty_error2 (fst s) ("duplicated subrule: "^(Auxl.dump_structure_entry s)) "" ) in
   let structure_crs = 
     List.map
       (fun cr -> (cr.cr_loc, (Struct_crs [(cr.cr_ntr, cr.cr_target, cr.cr_hole)])))

--- a/src/grammar_typecheck.ml
+++ b/src/grammar_typecheck.ml
@@ -561,8 +561,8 @@ let rec cd_hom hu c (es : element list) ((hn,hs,l0):raw_homomorphism): homomorph
 (* hmm - maybe we should check that this s is in fact one of the terminals *)
 (* of the grammar.  But that info isn't to hand (eg in c) at present *)
               if not (rule_has_terminal (snd id) es) then begin
-                Auxl.warning ("Free variables in hom element " ^ Grammar_pp.pp_raw_hom_spec_el hse 
-                              ^ " at " ^ Location.pp_loc l0)
+                Auxl.warning l0 ("Free variables in hom element " ^ Grammar_pp.pp_raw_hom_spec_el hse 
+                              )
               end;
               Hom_terminal (snd id) )
 	with 
@@ -1118,7 +1118,7 @@ and cd_element c (e:raw_element) : semiraw_element =
                   elb_es = es' } in
       Sr_el(Lang_list elb)
   | (Raw_sugaroption (_, _)|Raw_nelist (_, _)|Raw_list (_, _)|Raw_option (_, _))
-      -> Auxl.error "internal: sugaroption, nelist, list and option not supported"
+      -> Auxl.error None "internal: sugaroption, nelist, list and option not supported"
 
 and cd_comp_bound : cd_env -> raw_comp_bound -> bound * metavarroot
     = fun c rcb -> match rcb with
@@ -2741,13 +2741,13 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
       | (Struct_axs l1,Struct_axs l2) -> Struct_axs (l1@l2)
       | (Struct_sbs l1,Struct_sbs l2) -> Struct_sbs (l1@l2)
       | (Struct_fvs l1,Struct_fvs l2) -> Struct_fvs (l1@l2)
-      | _ -> Auxl.error "internal: collapsing incompatible structure elements.\n" in
+      | _ -> Auxl.error None "internal: collapsing incompatible structure elements.\n" in
 
     let out_c_a current auxfns =
       match current,auxfns with
       | None, [] -> []
       | Some (l,rsec), [] -> [(l,rsec)]
-      | None, xs -> Auxl.error "internal: out_c_a, auxfns but undefined current"
+      | None, xs -> Auxl.error None "internal: out_c_a, auxfns but undefined current"
       | Some (l,rsec), xs -> (l,rsec)::[(l,Struct_axs xs)]
     in
 

--- a/src/grammar_typecheck.ml
+++ b/src/grammar_typecheck.ml
@@ -382,7 +382,8 @@ let subrule (xd:syntaxdefn) (include_meta_prods:bool)
 	      ^ " cannot be matched in rule " ^ ru.rule_ntr_name) ""
       | [pu] -> (pl.prod_name,pu.prod_name)
       | pu::pu'::pus' -> 
-          Auxl.warning 
+          (* TIDI get loc *)
+          Auxl.warning  None
             ("production \""^pl.prod_name^"\" is a subproduction of more than one production: "^String.concat ", " (List.map (function pu -> "\""^pu.prod_name^"\"") pus) ^" (taking the first)\n");
           (pl.prod_name,pu.prod_name)
     )
@@ -561,7 +562,7 @@ let rec cd_hom hu c (es : element list) ((hn,hs,l0):raw_homomorphism): homomorph
 (* hmm - maybe we should check that this s is in fact one of the terminals *)
 (* of the grammar.  But that info isn't to hand (eg in c) at present *)
               if not (rule_has_terminal (snd id) es) then begin
-                Auxl.warning l0 ("Free variables in hom element " ^ Grammar_pp.pp_raw_hom_spec_el hse 
+                Auxl.warning (Some l0) ("Free variables in hom element " ^ Grammar_pp.pp_raw_hom_spec_el hse 
                               )
               end;
               Hom_terminal (snd id) )

--- a/src/grammar_typecheck.ml
+++ b/src/grammar_typecheck.ml
@@ -1324,7 +1324,7 @@ and cd_parsing_annotation all_prod_names (par:raw_parsing_annotations) : parsing
       (fun (raw_pn1,pa,raw_pn2) -> 
         check_prod_name raw_pn1;
         check_prod_name raw_pn2;
-        (raw_pn1, pa, raw_pn2)) 
+        (raw_pn1, pa, raw_pn2,par.raw_pa_loc)) 
     par.raw_pa_data
     
 and cd_parsing_annotations c pars =

--- a/src/grammar_typecheck.ml
+++ b/src/grammar_typecheck.ml
@@ -2315,7 +2315,11 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
       add_vertices fs (n+1) ((f,n,v)::acc) in
 
   let auxfn_names = Auxl.remove_duplicates 
-      (List.map (function (f,ntr,_)->f) auxfns) in
+      (List.map (function (f,ntr,loc)->f) auxfns) in
+
+  (*TODO make faster*)
+  let auxfn_loc f = (fun (_,_,l) -> l) (List.hd (List.filter (fun (ff,_,_) -> ff == f ) auxfns ) ) in
+  
 
   let vertex_info =  add_vertices auxfn_names 0 [] in
 
@@ -2372,11 +2376,11 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
       let ntmvrs = ntmvrs_of_component vs in
       match ntmvrs with
       | [ntmvr] -> (vs,ntmvr)
-      | [] -> ty_error (
+      | [] -> ty_error2 (auxfn_loc (auxfn_of_vertex (List.hd vs)) ) (
           "auxfns "
           ^ String.concat " " (List.map (function v->auxfn_of_vertex v) vs)
           ^ " have unconstrained result type") ""
-      | _ -> ty_error (
+      | _ -> ty_error2 (auxfn_loc (auxfn_of_vertex (List.hd vs)) ) (
           "auxfns "
           ^ String.concat " " (List.map (function v->auxfn_of_vertex v) vs)
           ^ " have overconstrained result type: "
@@ -2524,7 +2528,7 @@ let rec check_and_disambiguate m_tex (quotient_rules:bool) (generate_aux_rules:b
   let ctxrule_can_promote_hole ntr =
     let ntr_p = Auxl.promote_ntr xd (Auxl.primary_ntr_of_ntr xd ntr) in 
     if not (String.compare ntr ntr_p = 0)
-    then ty_error( "ctxrule_can_promote check failed: the type of hole "
+    then ty_error2 (Auxl.loc_of_ntr xd ntr) ( "ctxrule_can_promote check failed: the type of hole "
 		   ^ ntr ^ " can be promoted to " ^ ntr_p ) ""
     else () in
   List.iter (fun cr -> ctxrule_can_promote_hole cr.cr_hole) xd.xd_crs;

--- a/src/lex_menhir_pp.ml
+++ b/src/lex_menhir_pp.ml
@@ -255,7 +255,8 @@ let token_names_of_syntaxdefn yo xd : token_data =
             (try
 	      let hs = List.assoc "ocaml" mvd.mvd_rep in
 	      Grammar_pp.pp_hom_spec m xd hs
-            with Not_found -> Auxl.error ("ocamllex output: undefined ocaml hom for "^mvd.mvd_name^"\n")) in
+        (* TODO *)
+            with Not_found -> Auxl.error None ("ocamllex output: undefined ocaml hom for "^mvd.mvd_name^"\n")) in
           let ocamllex_hom_opt = 
             (try
 	      let hs = List.assoc "ocamllex" mvd.mvd_rep in
@@ -270,9 +271,11 @@ let token_names_of_syntaxdefn yo xd : token_data =
           | Some ocamllex_hom, false -> 
               Some (token_name_of mvd.mvd_name, mvd.mvd_name, TK_metavar(ocaml_type, Some ocamllex_hom))
           | None, false -> 
-              Auxl.error ("ocamllex output: no ocamllex or ocamllex-remove hom for "^mvd.mvd_name^"\n")
+          (* TODO *)
+              Auxl.error None ("ocamllex output: no ocamllex or ocamllex-remove hom for "^mvd.mvd_name^"\n")
           | Some ocamllex_hom, false -> 
-              Auxl.error ("ocamllex output: both ocamllex and ocamllex-remove hom for "^mvd.mvd_name^"\n")
+          (* TODO *)
+              Auxl.error None ("ocamllex output: both ocamllex and ocamllex-remove hom for "^mvd.mvd_name^"\n")
           | None, true -> 
               Some (token_name_of mvd.mvd_name, mvd.mvd_name, TK_metavar(ocaml_type, None))
           )
@@ -350,7 +353,8 @@ let pp_lex_systemdefn m sd oi =
 ;
       output_string fd "\n\n{\n}\n\n";
       close_out fd
-  | _ -> Auxl.error "must specify only one output file in the lex backend.\n"
+      (* TODO *)
+  | _ -> Auxl.error None "must specify only one output file in the lex backend.\n"
 
 
 (** ******************************************************************** *)
@@ -479,7 +483,8 @@ let rec element_data_of_element ts (allow_lists:bool) e : element_data =
           | (1,None)   -> "nonempty_list(" ^ body ^ ")"
           | (2,Some t) -> "separated_nonempty2_list(" ^ t ^ "," ^ body ^ ")"
           | (2,None)   -> "nonempty2_list(" ^ body ^ ")"
-          | (_,_)      -> Auxl.error ("unexpected length in pp_menhir_element") 
+          (* TODO *)
+          | (_,_)      -> Auxl.error None ("unexpected length in pp_menhir_element") 
         in
         let body0 = 
           (match element_data with
@@ -803,7 +808,8 @@ let pp_pp_raw_rule yo generate_aux_info xd ts r =
     (match Auxl.hom_spec_for_hom_name "pp-raw" r.rule_homs with 
     | Some hs -> 
         Some (pp_pp_raw_name r.rule_ntr_name ^ " " ^ Grammar_pp.pp_hom_spec (Menhir yo) xd hs ^"\n\n")
-    | None -> (Auxl.error ("no pp-raw hom for phantom production "^r.rule_ntr_name));
+        (* TODO *)
+    | None -> (Auxl.error None ("no pp-raw hom for phantom production "^r.rule_ntr_name));
     )
   else 
     let generate_aux_info_here = generate_aux_info_for_rule generate_aux_info r in 
@@ -845,7 +851,8 @@ let pp_pp_rule yo generate_aux_info xd ts r =
     (match Auxl.hom_spec_for_hom_name "pp" r.rule_homs with 
     | Some hs -> 
         Some (pp_pp_name r.rule_ntr_name ^ " " ^ Grammar_pp.pp_hom_spec (Menhir yo) xd hs ^"\n\n")
-    | None -> (Auxl.error ("no pp hom for phantom production "^r.rule_ntr_name));
+        (* TODO *)
+    | None -> (Auxl.error None ("no pp hom for phantom production "^r.rule_ntr_name));
     )
   else 
     let generate_aux_info_here = generate_aux_info_for_rule generate_aux_info r in 
@@ -914,7 +921,7 @@ let pp_menhir_syntaxdefn m sources _(*xd_quotiented*) xd_unquotiented lookup gen
       List.iter (function r -> output_string fd (pp_menhir_rule yo generate_aux_info xd_unquotiented ts r)) xd_unquotiented.xd_rs;
       close_out fd
 
-  | _ -> Auxl.error "must specify only one output file in the menhir backend.\n"
+  | _ -> Auxl.error None "must specify only one output file in the menhir backend.\n"
 
 (* output pp source file (should be called with quotiented syntaxdefn file) *)
 let pp_pp_syntaxdefn m sources xd_quotiented xd_unquotiented xd_quotiented_unaux generate_aux_info oi =
@@ -938,5 +945,5 @@ let pp_pp_syntaxdefn m sources xd_quotiented xd_unquotiented xd_quotiented_unaux
                         );
       close_out fd;
 
-  | _ -> Auxl.error "must specify only one output file in the menhir backend.\n"
+  | _ -> Auxl.error None "must specify only one output file in the menhir backend.\n"
 

--- a/src/lex_menhir_pp.ml
+++ b/src/lex_menhir_pp.ml
@@ -692,7 +692,7 @@ let pp_menhir_prod yo generate_aux_info_here xd ts r p =
 
 
 
-        | None -> ignore(Auxl.error ("no ocaml hom for production "^p.prod_name));"")
+        | None -> ignore(Auxl.error (*TODO*) None ("no ocaml hom for production "^p.prod_name));"")
     in
 
     let aux_wrapper_l, aux_wrapper_r = 

--- a/src/lex_menhir_pp.ml
+++ b/src/lex_menhir_pp.ml
@@ -255,7 +255,6 @@ let token_names_of_syntaxdefn yo xd : token_data =
             (try
 	      let hs = List.assoc "ocaml" mvd.mvd_rep in
 	      Grammar_pp.pp_hom_spec m xd hs
-        (* TODO *)
             with Not_found -> Auxl.error (Some mvd.mvd_loc) ("ocamllex output: undefined ocaml hom for "^mvd.mvd_name^"\n")) in
           let ocamllex_hom_opt = 
             (try
@@ -271,10 +270,8 @@ let token_names_of_syntaxdefn yo xd : token_data =
           | Some ocamllex_hom, false -> 
               Some (token_name_of mvd.mvd_name, mvd.mvd_name, TK_metavar(ocaml_type, Some ocamllex_hom))
           | None, false -> 
-          (* TODO *)
               Auxl.error (Some mvd.mvd_loc) ("ocamllex output: no ocamllex or ocamllex-remove hom for "^mvd.mvd_name^"\n")
           | Some ocamllex_hom, false -> 
-          (* TODO *)
               Auxl.error (Some mvd.mvd_loc) ("ocamllex output: both ocamllex and ocamllex-remove hom for "^mvd.mvd_name^"\n")
           | None, true -> 
               Some (token_name_of mvd.mvd_name, mvd.mvd_name, TK_metavar(ocaml_type, None))
@@ -353,7 +350,6 @@ let pp_lex_systemdefn m sd oi =
 ;
       output_string fd "\n\n{\n}\n\n";
       close_out fd
-      (* TODO *)
   | _ -> Auxl.error None "must specify only one output file in the lex backend.\n"
 
 
@@ -483,7 +479,6 @@ let rec element_data_of_element ts (allow_lists:bool) e : element_data =
           | (1,None)   -> "nonempty_list(" ^ body ^ ")"
           | (2,Some t) -> "separated_nonempty2_list(" ^ t ^ "," ^ body ^ ")"
           | (2,None)   -> "nonempty2_list(" ^ body ^ ")"
-          (* TODO *)
           | (_,_)      -> Auxl.error None ("unexpected length in pp_menhir_element") 
         in
         let body0 = 

--- a/src/lex_menhir_pp.ml
+++ b/src/lex_menhir_pp.ml
@@ -256,7 +256,7 @@ let token_names_of_syntaxdefn yo xd : token_data =
 	      let hs = List.assoc "ocaml" mvd.mvd_rep in
 	      Grammar_pp.pp_hom_spec m xd hs
         (* TODO *)
-            with Not_found -> Auxl.error None ("ocamllex output: undefined ocaml hom for "^mvd.mvd_name^"\n")) in
+            with Not_found -> Auxl.error (Some mvd.mvd_loc) ("ocamllex output: undefined ocaml hom for "^mvd.mvd_name^"\n")) in
           let ocamllex_hom_opt = 
             (try
 	      let hs = List.assoc "ocamllex" mvd.mvd_rep in
@@ -272,10 +272,10 @@ let token_names_of_syntaxdefn yo xd : token_data =
               Some (token_name_of mvd.mvd_name, mvd.mvd_name, TK_metavar(ocaml_type, Some ocamllex_hom))
           | None, false -> 
           (* TODO *)
-              Auxl.error None ("ocamllex output: no ocamllex or ocamllex-remove hom for "^mvd.mvd_name^"\n")
+              Auxl.error (Some mvd.mvd_loc) ("ocamllex output: no ocamllex or ocamllex-remove hom for "^mvd.mvd_name^"\n")
           | Some ocamllex_hom, false -> 
           (* TODO *)
-              Auxl.error None ("ocamllex output: both ocamllex and ocamllex-remove hom for "^mvd.mvd_name^"\n")
+              Auxl.error (Some mvd.mvd_loc) ("ocamllex output: both ocamllex and ocamllex-remove hom for "^mvd.mvd_name^"\n")
           | None, true -> 
               Some (token_name_of mvd.mvd_name, mvd.mvd_name, TK_metavar(ocaml_type, None))
           )

--- a/src/lex_menhir_pp.ml
+++ b/src/lex_menhir_pp.ml
@@ -657,6 +657,7 @@ let pp_menhir_prod yo generate_aux_info_here xd ts r p =
         let pp_menhir_hse hse = 
           match hse with
           | Hom_string s ->  s
+          (* TODO, arbitrary failure? *)
           | Hom_index i -> let e = List.nth es'' (*or es? *) i  in let d=element_data_of_element ts true e in (match d.semantic_action with Some s -> s | None -> raise (Failure ("pp_menhir_hse Hom_index " ^ string_of_int i ^ " at " ^ Location.pp_loc p.prod_loc)))
           | Hom_terminal s -> s
           | Hom_ln_free_index (mvs,s) -> raise (Failure "Hom_ln_free_index not implemented")  in

--- a/src/lex_menhir_pp.ml
+++ b/src/lex_menhir_pp.ml
@@ -692,7 +692,7 @@ let pp_menhir_prod yo generate_aux_info_here xd ts r p =
 
 
 
-        | None -> ignore(Auxl.error (*TODO*) None ("no ocaml hom for production "^p.prod_name));"")
+        | None -> ignore(Auxl.error (Some (r.rule_loc)) ("no ocaml hom for production "^p.prod_name));"")
     in
 
     let aux_wrapper_l, aux_wrapper_r = 
@@ -809,8 +809,7 @@ let pp_pp_raw_rule yo generate_aux_info xd ts r =
     (match Auxl.hom_spec_for_hom_name "pp-raw" r.rule_homs with 
     | Some hs -> 
         Some (pp_pp_raw_name r.rule_ntr_name ^ " " ^ Grammar_pp.pp_hom_spec (Menhir yo) xd hs ^"\n\n")
-        (* TODO *)
-    | None -> (Auxl.error None ("no pp-raw hom for phantom production "^r.rule_ntr_name));
+    | None -> (Auxl.error (Some r.rule_loc) ("no pp-raw hom for phantom production "^r.rule_ntr_name));
     )
   else 
     let generate_aux_info_here = generate_aux_info_for_rule generate_aux_info r in 
@@ -852,8 +851,7 @@ let pp_pp_rule yo generate_aux_info xd ts r =
     (match Auxl.hom_spec_for_hom_name "pp" r.rule_homs with 
     | Some hs -> 
         Some (pp_pp_name r.rule_ntr_name ^ " " ^ Grammar_pp.pp_hom_spec (Menhir yo) xd hs ^"\n\n")
-        (* TODO *)
-    | None -> (Auxl.error None ("no pp hom for phantom production "^r.rule_ntr_name));
+    | None -> (Auxl.error (Some r.rule_loc) ("no pp hom for phantom production "^r.rule_ntr_name));
     )
   else 
     let generate_aux_info_here = generate_aux_info_for_rule generate_aux_info r in 

--- a/src/ln_transform.ml
+++ b/src/ln_transform.ml
@@ -58,7 +58,7 @@ let rec collect_mv_in_mse mse =
   match mse with
   | MetaVarExp mv -> [mv]
   | Union (mse1,mse2) -> (collect_mv_in_mse mse1) @ (collect_mv_in_mse mse2) 
-  | _ -> Auxl.warning "internal: collect ln bindspec not implemented\n"; [] 
+  | _ -> Auxl.warning None "internal: collect ln bindspec not implemented\n"; [] 
 
 (* LIBRARY *)
 
@@ -97,7 +97,7 @@ let binders p =
 	 match bs with
 	 | Bind (MetaVarExp mv,_) -> Some [mv]
 	 | AuxFnDef (_,mse) -> Some (collect_mv_in_mse mse)
-	 | Bind _ -> Auxl.warning "internal: binders not implemented - 1\n"; None
+	 | Bind _ -> Auxl.warning None "internal: binders not implemented - 1\n"; None
 	 | _ -> None )
        p.prod_bs)
 
@@ -109,7 +109,7 @@ let binders_for_nt p nt =
 	 match bs with
 	 | Bind (MetaVarExp mv,nt1) when compare nt nt1 = 0 -> Some [mv]
 	 | Bind (MetaVarExp mv,nt1) when not (compare nt nt1 = 0) -> None
-	 | Bind _ -> Auxl.warning "internal: binders not implemented - 2\n"; None
+	 | Bind _ -> Auxl.warning None "internal: binders not implemented - 2\n"; None
 	 | _ -> None )
        p.prod_bs)
 
@@ -125,7 +125,7 @@ let is_bindable xd mv p =
 
 (* for a ln mvr, record the rules where it has been splitted *)
 let rules_with_bindable_mvr (xd:syntaxdefn) (mvr:metavarroot) : rule list =
-  if not((Auxl.mvd_of_mvr xd mvr).mvd_locally_nameless) then Auxl.error ("internal: rules_with_bindable_mvr: "^mvr^" does not have a ln repr.\n");
+  if not((Auxl.mvd_of_mvr xd mvr).mvd_locally_nameless) then Auxl.error None ("internal: rules_with_bindable_mvr: "^mvr^" does not have a ln repr.\n");
   List.filter
     (fun r -> 
       (not r.rule_meta) && 
@@ -200,20 +200,20 @@ let check_single_binder xd =
     List.iter (fun bs ->
       match bs with
       | AuxFnDef _ -> 
-	  Auxl.warning "locally-nameless: auxfns are not supported by the locally-nameless backend\n"
+	  (* TODO *) Auxl.warning None "locally-nameless: auxfns are not supported by the locally-nameless backend\n"
       | Bind (NonTermExp _,_) -> 
-	  Auxl.warning "locally-nameless: bindspec binding a nonterminal are not supported by the locally-nameless backend\n"
+	  (* TODO *) Auxl.warning None "locally-nameless: bindspec binding a nonterminal are not supported by the locally-nameless backend\n"
       | Bind (MetaVarListExp _,_) ->
-	  Auxl.warning "locally-nameless: bindspec binding a list of metavars are not supported by the locally-nameless backend\n"
+	  (* TODO *) Auxl.warning None "locally-nameless: bindspec binding a list of metavars are not supported by the locally-nameless backend\n"
       | Bind (NonTermListExp _,_) ->
-	  Auxl.warning "locally-nameless: bindspec binding a list of nonterminals are not supported by the locally-nameless backend\n"
+	  (* TODO *) Auxl.warning None "locally-nameless: bindspec binding a list of nonterminals are not supported by the locally-nameless backend\n"
       | Bind (MetaVarExp mv,_) ->
           (* check if mv has a locally nameless representation *)
           let mvd = Auxl.mvd_of_mvr xd (Auxl.primary_mvr_of_mvr xd (fst mv)) in
           if mvd.mvd_locally_nameless then
 	    if !one_bind
 	    then 
-	      Auxl.warning "locally-nameless: multiple bind declaration on the same production are not supported by the locally-nameless backend\n"
+	      (* TODO *) Auxl.warning None "locally-nameless: multiple bind declaration on the same production are not supported by the locally-nameless backend\n"
 	    else one_bind := true
           else ()
       | _ -> ())
@@ -682,7 +682,7 @@ let pp_open_prod m xd mvr wrt (ov:string) (rule_ntr_name:nontermroot) (p:prod) :
 	  let mv1_s = Grammar_pp.pp_metavar_with_de_with_sie m xd sie de mv1 in
 	  let mv2_s = Grammar_pp.pp_metavar_with_de_with_sie m xd sie de mv2 in
 	  ( "if (k === "^mv1_s^") then (List.nth "^mv2_s^" "^ov^" "^"("^p.prod_name^" 0 0)"^") else (" ^ s^ " "^mv1_s^" "^mv2_s^")" , [] )
-      | _ -> Auxl.error "internal: weird lhs_stnb in pp_open_prod\n" )
+      | _ -> Auxl.error None "internal: weird lhs_stnb in pp_open_prod\n" )
       
     else (
       let unshifted_nonterms = 
@@ -778,7 +778,7 @@ let pp_open m xd : int_funcs_collapsed =
 	{ i_funcs = ifuncs;
 	  i_funcs_proof = None }
 
-  | _ -> Auxl.warning "internal: pp_open implemented only for Coq\n"; []
+  | _ -> Auxl.warning None "internal: pp_open implemented only for Coq\n"; []
 
 (* ******************************************************************** *)
 (* lc (locally closed)                                                  *)
@@ -849,7 +849,8 @@ let pp_lcs fd m xd : unit =
 	    ("lcs, rule "^r.rule_ntr_name^", binders in prod "
 	     ^ p.prod_name^ " for ntr "^ntr ^ " = "^String.concat " , " (List.map Grammar_pp.pp_plain_metavar mvs));
 
-	  if List.length mvs > 1 then Auxl.error "locally_nameless - not implemented: several mvs bind the same nt\n";
+(* TODO *)
+	  if List.length mvs > 1 then Auxl.error None "locally_nameless - not implemented: several mvs bind the same nt\n";
 
 	  if List.length mvs = 1 
 	      (* build premise with cofinite quantification *)
@@ -870,7 +871,7 @@ let pp_lcs fd m xd : unit =
 		in
 		p.prod_name
 	      with Not_found -> 
-		Auxl.error ("internal: lns, make_premises, cannot find singleton production for "
+		Auxl.error None ("internal: lns, make_premises, cannot find singleton production for "
 			    ^ (fst (List.hd mvs)) ^ " starting from rule " ^ r.rule_ntr_name ^ "\n")
 	    in
 	    let st_rule_name_s = 
@@ -1163,14 +1164,14 @@ let build_open_symterm m xd open_wrt st =
     match st with
     | St_nonterm (_,ntr,_) -> Auxl.primary_ntr_of_ntr xd ntr
     | St_nontermsub (_,_,ntr,_) -> Auxl.primary_ntr_of_ntr xd ntr
-    | _ -> Auxl.error "internal: build_open_symterm, not a nonterm\n" in
+    | _ -> Auxl.error None "internal: build_open_symterm, not a nonterm\n" in
   let r = Auxl.rule_of_ntr xd ntr in
   let find_var_prod mv =
     let mv1 = 
       match mv with
       | Ste_metavar (_,mv1,_) -> mv1
       | Ste_var (_,mv1,_) -> mv1
-      | _ -> Auxl.error "internal: find_var_prod ln not ste_metavar\n" in
+      | _ -> Auxl.error None "internal: find_var_prod ln not ste_metavar\n" in
     let p = List.find
 	( fun p ->
 	  match p.prod_es with
@@ -1187,7 +1188,7 @@ let build_open_symterm m xd open_wrt st =
       match mv with
       | Ste_metavar (_,mv1,_) -> mv1
       | Ste_var (_,mv1,_) -> mv1
-      | _ -> Auxl.error "internal: find_var_prod ln not ste_metavar\n" in
+      | _ -> Auxl.error None "internal: find_var_prod ln not ste_metavar\n" in
 
     let r = List.find
 	(fun r ->
@@ -1351,7 +1352,7 @@ let ln_transform_symterms (m:pp_mode) (xd:syntaxdefn) (stlp:(string option * sym
 	then None
 	else Some (Ste_var (l,mvrp,var))
     | (Ste_list (l,stlis),_) -> 
-	(* Auxl.warning "internal: remove_binders_symterm_element ste_list not implemented\n"; *)
+	(* Auxl.warning None "internal: remove_binders_symterm_element ste_list not implemented\n"; *)
 	Some (Ste_list (l,stlis)) (* FZ *)
   in
 
@@ -1457,7 +1458,7 @@ let ln_transform_symterms (m:pp_mode) (xd:syntaxdefn) (stlp:(string option * sym
 	   ( fun ste ->
 	     match ste with
 	     | Ste_metavar (_,mvr,mv) -> (ste,(Ste_var (dummy_loc,mvr, ((*"TX_"^*)(Grammar_pp.pp_plain_metavar mv)))))
-	     | _ -> Auxl.error "internal: nt_longest" )
+	     | _ -> Auxl.error None "internal: nt_longest" )
 	   stel ))
       nt_longest in
 
@@ -1519,7 +1520,8 @@ let ln_transform_symterms (m:pp_mode) (xd:syntaxdefn) (stlp:(string option * sym
 			     let current_str = List.map Grammar_pp.pp_plain_symterm_element current_binding in
 			     List.iter
 			       (fun str -> if List.mem str current_str 
-			       then Auxl.error ("locally-nameless: a rule definition contains a repeated binder: "^str^";\n  try alpha-converting one of the occurrences.\n"))
+             (* TODO *)
+			       then Auxl.error None ("locally-nameless: a rule definition contains a repeated binder: "^str^";\n  try alpha-converting one of the occurrences.\n"))
 			       (List.map Grammar_pp.pp_plain_symterm_element extra_binders);
 			       
 			       let binders = 
@@ -1577,7 +1579,7 @@ let ln_transform_symterms (m:pp_mode) (xd:syntaxdefn) (stlp:(string option * sym
       match mvsr with
       | [] -> st
       | mv::tl ->
-	  let mvr = match mv with Ste_metavar (_,mvr,_) -> mvr | Ste_var (_,mvr,_) -> mvr | _ -> Auxl.error "internal: cofinite quantify not metavar" in
+	  let mvr = match mv with Ste_metavar (_,mvr,_) -> mvr | Ste_var (_,mvr,_) -> mvr | _ -> Auxl.error None "internal: cofinite quantify not metavar" in
 	  let cq_st =
 	    St_node ( dummy_loc,
 		      { st_rule_ntr_name = "formula";
@@ -1637,7 +1639,7 @@ let ln_transform_defn m xd d =
     List.map 
       (fun psr -> match psr with 
       | PSR_Rule dr -> PSR_Rule (ln_transform_drule m xd dr)
-      | PSR_Defncom _ -> Auxl.error "internal: ln transform defncom not implemented" )
+      | PSR_Defncom _ -> Auxl.error None "internal: ln transform defncom not implemented" )
       d.d_rules }
 
 let ln_transform_reln_defnclass m xd dc =
@@ -1648,7 +1650,7 @@ let ln_transform_fun_or_reln_defnclass_list
     m (xd:syntaxdefn) (frdcs:fun_or_reln_defnclass list) : fun_or_reln_defnclass list =
   List.map 
     ( fun frdc -> match frdc with
-    | FDC fdc -> Auxl.error "internal: fdc transform not implemented" 
+    | FDC fdc -> Auxl.error None "internal: fdc transform not implemented" 
     | RDC dc -> RDC (ln_transform_reln_defnclass m xd dc)
     ) frdcs
 

--- a/src/ln_transform.ml
+++ b/src/ln_transform.ml
@@ -200,20 +200,20 @@ let check_single_binder xd =
     List.iter (fun bs ->
       match bs with
       | AuxFnDef (loc,_,_) -> 
-	  (* TODO *) Auxl.warning (Some loc) "locally-nameless: auxfns are not supported by the locally-nameless backend\n"
+	  Auxl.warning (Some loc) "locally-nameless: auxfns are not supported by the locally-nameless backend\n"
       | Bind (loc,NonTermExp _,_) -> 
-	  (* TODO *) Auxl.warning (Some loc) "locally-nameless: bindspec binding a nonterminal are not supported by the locally-nameless backend\n"
+	  Auxl.warning (Some loc) "locally-nameless: bindspec binding a nonterminal are not supported by the locally-nameless backend\n"
       | Bind (loc,MetaVarListExp _,_) ->
-	  (* TODO *) Auxl.warning (Some loc) "locally-nameless: bindspec binding a list of metavars are not supported by the locally-nameless backend\n"
+	  Auxl.warning (Some loc) "locally-nameless: bindspec binding a list of metavars are not supported by the locally-nameless backend\n"
       | Bind (loc,NonTermListExp _,_) ->
-	  (* TODO *) Auxl.warning (Some loc) "locally-nameless: bindspec binding a list of nonterminals are not supported by the locally-nameless backend\n"
+	  Auxl.warning (Some loc) "locally-nameless: bindspec binding a list of nonterminals are not supported by the locally-nameless backend\n"
       | Bind (loc,MetaVarExp mv,_) ->
           (* check if mv has a locally nameless representation *)
           let mvd = Auxl.mvd_of_mvr xd (Auxl.primary_mvr_of_mvr xd (fst mv)) in
           if mvd.mvd_locally_nameless then
 	    if !one_bind
 	    then 
-	      (* TODO *) Auxl.warning (Some mvd.mvd_loc) "locally-nameless: multiple bind declaration on the same production are not supported by the locally-nameless backend\n"
+	      Auxl.warning (Some mvd.mvd_loc) "locally-nameless: multiple bind declaration on the same production are not supported by the locally-nameless backend\n"
 	    else one_bind := true
           else ()
       | _ -> ())

--- a/src/ln_transform.ml
+++ b/src/ln_transform.ml
@@ -95,8 +95,8 @@ let binders p =
        ( fun bs -> 
 	 (* print_endline (Grammar_pp.pp_plain_bindspec bs); *)
 	 match bs with
-	 | Bind (MetaVarExp mv,_) -> Some [mv]
-	 | AuxFnDef (_,mse) -> Some (collect_mv_in_mse mse)
+	 | Bind (loc,MetaVarExp mv,_) -> Some [mv]
+	 | AuxFnDef (loc,_,mse) -> Some (collect_mv_in_mse mse)
 	 | Bind _ -> Auxl.warning None "internal: binders not implemented - 1\n"; None
 	 | _ -> None )
        p.prod_bs)
@@ -107,8 +107,8 @@ let binders_for_nt p nt =
        ( fun bs -> 
 	 (* print_endline (Grammar_pp.pp_plain_bindspec bs); *)
 	 match bs with
-	 | Bind (MetaVarExp mv,nt1) when compare nt nt1 = 0 -> Some [mv]
-	 | Bind (MetaVarExp mv,nt1) when not (compare nt nt1 = 0) -> None
+	 | Bind (loc,MetaVarExp mv,nt1) when compare nt nt1 = 0 -> Some [mv]
+	 | Bind (loc,MetaVarExp mv,nt1) when not (compare nt nt1 = 0) -> None
 	 | Bind _ -> Auxl.warning None "internal: binders not implemented - 2\n"; None
 	 | _ -> None )
        p.prod_bs)
@@ -199,15 +199,15 @@ let check_single_binder xd =
     let one_bind = ref false in
     List.iter (fun bs ->
       match bs with
-      | AuxFnDef _ -> 
-	  (* TODO *) Auxl.warning None "locally-nameless: auxfns are not supported by the locally-nameless backend\n"
-      | Bind (NonTermExp _,_) -> 
-	  (* TODO *) Auxl.warning None "locally-nameless: bindspec binding a nonterminal are not supported by the locally-nameless backend\n"
-      | Bind (MetaVarListExp _,_) ->
-	  (* TODO *) Auxl.warning None "locally-nameless: bindspec binding a list of metavars are not supported by the locally-nameless backend\n"
-      | Bind (NonTermListExp _,_) ->
-	  (* TODO *) Auxl.warning None "locally-nameless: bindspec binding a list of nonterminals are not supported by the locally-nameless backend\n"
-      | Bind (MetaVarExp mv,_) ->
+      | AuxFnDef (loc,_,_) -> 
+	  (* TODO *) Auxl.warning (Some loc) "locally-nameless: auxfns are not supported by the locally-nameless backend\n"
+      | Bind (loc,NonTermExp _,_) -> 
+	  (* TODO *) Auxl.warning (Some loc) "locally-nameless: bindspec binding a nonterminal are not supported by the locally-nameless backend\n"
+      | Bind (loc,MetaVarListExp _,_) ->
+	  (* TODO *) Auxl.warning (Some loc) "locally-nameless: bindspec binding a list of metavars are not supported by the locally-nameless backend\n"
+      | Bind (loc,NonTermListExp _,_) ->
+	  (* TODO *) Auxl.warning (Some loc) "locally-nameless: bindspec binding a list of nonterminals are not supported by the locally-nameless backend\n"
+      | Bind (loc,MetaVarExp mv,_) ->
           (* check if mv has a locally nameless representation *)
           let mvd = Auxl.mvd_of_mvr xd (Auxl.primary_mvr_of_mvr xd (fst mv)) in
           if mvd.mvd_locally_nameless then
@@ -689,7 +689,7 @@ let pp_open_prod m xd mvr wrt (ov:string) (rule_ntr_name:nontermroot) (p:prod) :
 	Auxl.option_map
 	  ( fun bs -> 
 	    match bs with 
-	    | Bind (MetaVarExp (mvr1,_),nt) -> 
+	    | Bind (loc, MetaVarExp (mvr1,_),nt) -> 
 		let mvr1 = Auxl.primary_mvr_of_mvr xd mvr1 in
 		if (String.compare mvr mvr1 = 0) then Some nt else None
 	    | _ -> None )
@@ -1051,7 +1051,7 @@ let pp_arity_prod m xd_transformed f ntr p =
       (Auxl.option_map
 	 ( fun bs -> 
 	   match bs with
-	   | AuxFnDef (f',mse) when String.compare f f' = 0 -> Some mse
+	   | AuxFnDef (loc,f',mse) when String.compare f f' = 0 -> Some mse
 	   | _ -> None )
 	 p.prod_bs) in
   let rec mse_to_rhs mse =
@@ -1368,7 +1368,7 @@ let ln_transform_symterms (m:pp_mode) (xd:syntaxdefn) (stlp:(string option * sym
 	  Auxl.option_map
 	    ( fun bs -> 
 	      match bs with
-	      | Bind (MetaVarExp mv, nt) -> 
+	      | Bind (loc,MetaVarExp mv, nt) -> 
 		  let mvo = List.nth stnb.st_es (find_occurrence_mv p.prod_es 0 mv) in
 		  let o = find_occurrence_nt nt p.prod_es 1 in
 		  Some (mvo,nt,o,(St_node (l,stnb)))     
@@ -1484,7 +1484,7 @@ let ln_transform_symterms (m:pp_mode) (xd:syntaxdefn) (stlp:(string option * sym
 	  Auxl.option_map
 	    ( fun bs -> 
 	      match bs with
-	      | Bind (MetaVarExp mv, nt) -> 
+	      | Bind (loc,MetaVarExp mv, nt) -> 
 		  let mvo = List.nth stnb.st_es (find_occurrence_mv p.prod_es 0 mv) in
 		  let o = find_occurrence_nt nt p.prod_es 1 in
 		  Some (mvo,nt,o) 

--- a/src/ln_transform.ml
+++ b/src/ln_transform.ml
@@ -849,7 +849,6 @@ let pp_lcs fd m xd : unit =
 	    ("lcs, rule "^r.rule_ntr_name^", binders in prod "
 	     ^ p.prod_name^ " for ntr "^ntr ^ " = "^String.concat " , " (List.map Grammar_pp.pp_plain_metavar mvs));
 
-(* TODO *)
 	  if List.length mvs > 1 then Auxl.error None "locally_nameless - not implemented: several mvs bind the same nt\n";
 
 	  if List.length mvs = 1 

--- a/src/location.ml
+++ b/src/location.ml
@@ -129,7 +129,7 @@ let dummy_t =
   { loc_start=dummy_pos;
     loc_end=dummy_pos }
 
-let pp_loc l = String.concat " " ((List.map pp_t) l)
+let pp_loc l = String.concat " ; " ((List.map pp_t) l)
 
 let pos_plus_offset pos n = {pos with
                              Lexing.pos_bol = pos.Lexing.pos_bol + n;

--- a/src/location.ml
+++ b/src/location.ml
@@ -74,10 +74,10 @@ let pp_t {loc_start=ls;loc_end=le} =
       && ls.Lexing.pos_lnum = le.Lexing.pos_lnum 
   then 
     (* start and end are in the same file and line *)
-    (if ls.Lexing.pos_fname="" then "" else "file " ^ ls.Lexing.pos_fname ^ "  ")
+    (if ls.Lexing.pos_fname="" then "" else "File " ^ ls.Lexing.pos_fname ^ " on ")
     ^ "line "
     ^ string_of_int ls.Lexing.pos_lnum
-    ^ " char "
+    ^ ", column "
     ^ string_of_int (ls.Lexing.pos_cnum - ls.Lexing.pos_bol)
     ^ " - "
     ^ string_of_int (le.Lexing.pos_cnum - le.Lexing.pos_bol)
@@ -86,22 +86,22 @@ let pp_t {loc_start=ls;loc_end=le} =
       && le.Lexing.pos_cnum - le.Lexing.pos_bol = 0 
   then
     (* start and end are in the same file but different lines, at the starts of those lines *)
-    (if ls.Lexing.pos_fname="" then "" else "file " ^ ls.Lexing.pos_fname ^ "  ")
+    (if ls.Lexing.pos_fname="" then "" else "File " ^ ls.Lexing.pos_fname ^ " on ")
     ^ "line "
     ^ string_of_int ls.Lexing.pos_lnum
     ^ " - "
     ^ string_of_int le.Lexing.pos_lnum
   else 
     (* start and end are in the same file but different lines, at some non-start chars *)
-    (if ls.Lexing.pos_fname="" then "" else "file " ^ ls.Lexing.pos_fname ^ "  ")
+    (if ls.Lexing.pos_fname="" then "" else "File " ^ ls.Lexing.pos_fname ^ " on ")
     ^ "line "
     ^ string_of_int ls.Lexing.pos_lnum
-    ^ " char "
+    ^ ", column "
     ^ string_of_int (ls.Lexing.pos_cnum - ls.Lexing.pos_bol)
     ^ " - " 
     ^ "line "
     ^ string_of_int le.Lexing.pos_lnum
-    ^ " char "
+    ^ ", column "
     ^ string_of_int (le.Lexing.pos_cnum - le.Lexing.pos_bol)
 
 

--- a/src/location.ml
+++ b/src/location.ml
@@ -50,7 +50,10 @@ let loc_of_filename name len  =
       Lexing.pos_cnum =len }
 } ]
 
-let pp_position 
+(* We don't use these anymore,
+since all errors/warnings should be converting
+their positiosn into locations *)
+(* let pp_position 
     { Lexing.pos_fname = f;
       Lexing.pos_lnum = l;
       Lexing.pos_bol = b;
@@ -58,13 +61,13 @@ let pp_position
   "fname=" ^ f ^ "  lnum=" ^ string_of_int l
   ^ "  bol="^string_of_int b^"  cnum=" ^string_of_int c
 
-let pp_position2  
+let pp_position2'  
     { Lexing.pos_fname = f;
       Lexing.pos_lnum = l;
       Lexing.pos_bol = b;
       Lexing.pos_cnum = c } = 
   (if f="" then "" else "file=" ^ f ^ "  ")
-  ^ "line=" ^ string_of_int l ^ "  char=" ^ string_of_int (c-b)
+  ^ "line=" ^ string_of_int l ^ "  char=" ^ string_of_int (c-b) *)
 
 let pp_t {loc_start=ls;loc_end=le} = 
   if ls.Lexing.pos_fname = le.Lexing.pos_fname 

--- a/src/main.ml
+++ b/src/main.ml
@@ -846,7 +846,7 @@ let _ =
            Gc.minor_heap_size = 2*1024*1024      (*  8/16 MB in 32/64bit machines *); 
            Gc.major_heap_increment = 5*1024*1024 (* 40/80 MB in 32/64bit machines *)};;
 
-let _ = match source_filenames, !read_systemdefn_filename_opt with
+let _ = try ( match source_filenames, !read_systemdefn_filename_opt with
 | (_::_),None -> 
     let (sd,lookup,sd_unquotiented,sd_quotiented_unaux) = process source_filenames in
     output_stage (sd,lookup,sd_unquotiented,sd_quotiented_unaux)
@@ -857,3 +857,6 @@ let _ = match source_filenames, !read_systemdefn_filename_opt with
     Arg.usage options usage_msg;
     Auxl.error None "\nError: must specify either some source filenames or a readsys option\n"
 | (_::_),Some _ -> Auxl.error None "\nError: must not specify both source filenames and a readsys option\n"
+                      
+  ) with 
+  | Auxl.Located_Failure (l, s) -> Auxl.exit_with l s

--- a/src/main.ml
+++ b/src/main.ml
@@ -179,7 +179,7 @@ let options = Arg.align [
 
 (* options for ascii output *)
   ( "-colour", 
-    Arg.Bool (fun b -> colour := b), 
+    Arg.Bool (fun b -> Auxl.colour := b; colour := b), 
     "<"^string_of_bool !colour ^">         Use (vt220) colour for ASCII pretty print" ); 
   ( "-show_sort", 
     Arg.Bool (fun b -> show_sort := b), 

--- a/src/main.ml
+++ b/src/main.ml
@@ -545,8 +545,6 @@ let process source_filenames =
               process_input ()
         with 
           My_parse_error (loc, s)->
-          (* TODO *)
-         (*  Auxl.error ("\n"^s^" in file: "^filter_filename^"\n") in*)
             Auxl.error loc ("\n"^s^"\n") in
       process_input ();
       output_string c' "\\end{alltt}\n";
@@ -607,8 +605,7 @@ let process source_filenames =
       Grammar_typecheck.check_and_disambiguate m_tex quotient generate_aux targets_non_tex (List.map snd source_filenames) (!merge_fragments) document 
     with
     | Typecheck_error (loc,s1,s2) ->
-    (* TODO *)
-        Auxl.error loc ("(in checking and disambiguating "^(if quotient then "quotiented " else "") ^ "syntax)\n"^s1
+        Auxl.error (Some loc) ("(in checking and disambiguating "^(if quotient then "quotiented " else "") ^ "syntax)\n"^s1
                     ^ (if s2<>"" then " ("^s2^")" else "")
                     ^ "\n")
   in
@@ -645,7 +642,7 @@ let process source_filenames =
     Grammar_typecheck.check_with_parser lookup xd
   with
   | Typecheck_error (loc,s1,s2) ->
-      Auxl.error loc ("(in checking syntax)\n"^s1
+      Auxl.error (Some loc) ("(in checking syntax)\n"^s1
               ^ (if s2<>"" then " ("^s2^")\n" else "\n"))
   end;
 
@@ -664,7 +661,7 @@ let process source_filenames =
        | Defns.Rule_parse_error (loc,s) ->
        Auxl.error (Some loc) ("\nError in processing definitions:\n"^s^"\n")
        | Bounds.Bounds (loc,s)  | Typecheck_error (loc,s,_)->
-       Auxl.error loc ("\nError in processing definitions:\n"^s^"\n")    
+       Auxl.error (Some loc) ("\nError in processing definitions:\n"^s^"\n")    
       )
     else
       (print_endline "********** NOT PROCESSING DEFINITIONS *************\n"; flush stdout;
@@ -753,7 +750,6 @@ let output_stage (sd,lookup,sd_unquotiented,sd_quotiented_unaux) =
             | 0 -> sd
             | 1 -> Auxl.avoid_primaries_systemdefn false sd
             | 2 -> Auxl.avoid_primaries_systemdefn true sd
-            (* TODO? *)
             | _ -> Auxl.error None "coq type-name avoidance must be in {0,1,2}" ) in
           System_pp.pp_systemdefn_core_io m_coq sd lookup fi !merge_fragments
       | "isa" ->
@@ -819,7 +815,6 @@ let output_stage (sd,lookup,sd_unquotiented,sd_quotiented_unaux) =
     with 
     | Parsing.Parse_error ->
         Auxl.error None ("unfiltered document "^src_filename^" cannot be parsed\n") 
-        (* TODO *)
     | My_parse_error (loc,s) -> Auxl.error loc s
     in
     Embed_pp.pp_embed_spec fd_dst m sd.syntax lookup (Auxl.collapse_embed_spec_el_list unfiltered_document);

--- a/src/main.ml
+++ b/src/main.ml
@@ -544,10 +544,10 @@ let process source_filenames =
               output_string c' (Grammar_lexer.de_lex_tex t); flush c';
               process_input ()
         with 
-          My_parse_error s->
+          My_parse_error (loc, s)->
           (* TODO *)
          (*  Auxl.error ("\n"^s^" in file: "^filter_filename^"\n") in*)
-            Auxl.error None ("\n"^s^"\n") in
+            Auxl.error loc ("\n"^s^"\n") in
       process_input ();
       output_string c' "\\end{alltt}\n";
       let _ = close_in c in
@@ -565,9 +565,9 @@ let process source_filenames =
           (try
             Grammar_parser.main (Grammar_lexer.my_lexer true Grammar_lexer.metalang) lexbuf
           with 
-            My_parse_error s->
+            My_parse_error (loc,s)->
 (*      Auxl.error ("\n"^s^" in file: "^filter_filename^"\n") in*)
-              Auxl.error None ("\n"^s^"\n")) in
+              Auxl.error loc ("\n"^s^"\n")) in
         let _ = close_in c in
         ris
     | _ -> 
@@ -820,7 +820,7 @@ let output_stage (sd,lookup,sd_unquotiented,sd_quotiented_unaux) =
     | Parsing.Parse_error ->
         Auxl.error None ("unfiltered document "^src_filename^" cannot be parsed\n") 
         (* TODO *)
-    | My_parse_error s -> Auxl.error None s
+    | My_parse_error (loc,s) -> Auxl.error loc s
     in
     Embed_pp.pp_embed_spec fd_dst m sd.syntax lookup (Auxl.collapse_embed_spec_el_list unfiltered_document);
     let _ = close_in fd_src in

--- a/src/new_term_parser.ml
+++ b/src/new_term_parser.ml
@@ -901,7 +901,7 @@ let build_grammar (xd : syntaxdefn)
     end; 
 
     List.iter
-      (fun (pn1, annot, pn2) ->
+      (fun (pn1, annot, pn2, loc) ->
          let (i1, i1') = Hashtbl.find prodname_to_index2 pn1 in
          let (i2, i2') = Hashtbl.find prodname_to_index2 pn2 in
          let entry = 

--- a/src/subrules_pp.ml
+++ b/src/subrules_pp.ml
@@ -488,7 +488,6 @@ let pp_subrules m xd srs : int_funcs_collapsed =
 	    ( Auxl.pp_is srl sru ^ " : " 
 	      ^ Grammar_pp.pp_nontermroot_ty m xd sru
 	      ^ " -> type.\n", "","")
-        (* TODO *)
         | Tex _ | Ascii _ | Lex _ | Menhir _ -> Auxl.error (Some (Auxl.loc_of_ntr xd srl)) "pp_subprod"
          ) in
 

--- a/src/subrules_pp.ml
+++ b/src/subrules_pp.ml
@@ -488,7 +488,8 @@ let pp_subrules m xd srs : int_funcs_collapsed =
 	    ( Auxl.pp_is srl sru ^ " : " 
 	      ^ Grammar_pp.pp_nontermroot_ty m xd sru
 	      ^ " -> type.\n", "","")
-        | Tex _ | Ascii _ | Lex _ | Menhir _ -> Auxl.error "pp_subprod"
+        (* TODO *)
+        | Tex _ | Ascii _ | Lex _ | Menhir _ -> Auxl.error None "pp_subprod"
          ) in
 
 

--- a/src/subrules_pp.ml
+++ b/src/subrules_pp.ml
@@ -489,7 +489,7 @@ let pp_subrules m xd srs : int_funcs_collapsed =
 	      ^ Grammar_pp.pp_nontermroot_ty m xd sru
 	      ^ " -> type.\n", "","")
         (* TODO *)
-        | Tex _ | Ascii _ | Lex _ | Menhir _ -> Auxl.error None "pp_subprod"
+        | Tex _ | Ascii _ | Lex _ | Menhir _ -> Auxl.error (Some (Auxl.loc_of_ntr xd srl)) "pp_subprod"
          ) in
 
 

--- a/src/substs_pp.ml
+++ b/src/substs_pp.ml
@@ -1435,8 +1435,7 @@ let pp_subst_rule : subst -> pp_mode -> syntaxdefn -> nontermroot list -> rule -
                ^ Grammar_pp.pp_nontermroot_ty m xd r.rule_ntr_name ^ " -> "
 	       ^ Grammar_pp.pp_nontermroot_ty m xd r.rule_ntr_name ^ " -> type.\n")
 	    )  , "", "")
-      (* TODO *)
-      | Ascii _ | Tex _ | Lex _ | Menhir _ -> Auxl.error None "pp_subst_rule")
+      | Ascii _ | Tex _ | Lex _ | Menhir _ -> Auxl.error (Some r.rule_loc) "pp_subst_rule")
   
     in 
     
@@ -1746,8 +1745,7 @@ and pp_fv_symterm_list_body
                  | _ -> Some "[]"), funcs
       | _ -> 
 	  ( match m with 
-    (* TODO *)
-          | Ascii _ | Tex _ | Lex _ | Menhir _ -> Auxl.error None "pp_fv_symterm_list_body"
+          | Ascii _ | Tex _ | Lex _ | Menhir _ -> Auxl.error (Some p.prod_loc) "pp_fv_symterm_list_body"
 	  | Isa io when io.ppi_isa_primrec ->
               let args = 
 	        String.concat "_" 

--- a/src/substs_pp.ml
+++ b/src/substs_pp.ml
@@ -1435,7 +1435,8 @@ let pp_subst_rule : subst -> pp_mode -> syntaxdefn -> nontermroot list -> rule -
                ^ Grammar_pp.pp_nontermroot_ty m xd r.rule_ntr_name ^ " -> "
 	       ^ Grammar_pp.pp_nontermroot_ty m xd r.rule_ntr_name ^ " -> type.\n")
 	    )  , "", "")
-      | Ascii _ | Tex _ | Lex _ | Menhir _ -> Auxl.error "pp_subst_rule")
+      (* TODO *)
+      | Ascii _ | Tex _ | Lex _ | Menhir _ -> Auxl.error None "pp_subst_rule")
   
     in 
     
@@ -1745,7 +1746,8 @@ and pp_fv_symterm_list_body
                  | _ -> Some "[]"), funcs
       | _ -> 
 	  ( match m with 
-          | Ascii _ | Tex _ | Lex _ | Menhir _ -> Auxl.error "pp_fv_symterm_list_body"
+    (* TODO *)
+          | Ascii _ | Tex _ | Lex _ | Menhir _ -> Auxl.error None "pp_fv_symterm_list_body"
 	  | Isa io when io.ppi_isa_primrec ->
               let args = 
 	        String.concat "_" 

--- a/src/substs_pp.ml
+++ b/src/substs_pp.ml
@@ -245,7 +245,7 @@ let auxfn_usages (bs : bindspec list) : (auxfn * nonterm) list =
   let all_binding_mses = 
     Auxl.option_map 
       (function b -> match b with
-      | Bind(mse,nt) -> Some(mse)
+      | Bind(loc,mse,nt) -> Some(mse)
       | _ -> None)
       bs in
   Auxl.remove_duplicates 
@@ -286,7 +286,7 @@ let pp_auxfn_clauses m xd f ntr ntmvr =
         Auxl.option_map 
           ( fun b -> 
 	    match b with 
-	    | AuxFnDef(f',mse) when f'=f -> Some mse
+	    | AuxFnDef(loc,f',mse) when f'=f -> Some mse
 	    | _ -> None ) 
           p.prod_bs with
       | [mse] -> mse
@@ -456,7 +456,7 @@ let glommed_bound_things_for_nonterm
   let relevant_bind_clauses_around_this_nonterm : (mse * nonterm) list = 
     Auxl.option_map 
       (function b -> match b with
-      | Bind(mse',nt') -> 
+      | Bind(loc,mse',nt') -> 
           if nt'=nt &&
             Auxl.result_type_of_mse xd mse'= that_var_root then Some (mse',nt)
           else None
@@ -492,7 +492,7 @@ let glommed_bound_things_for_nonterm
     | Empty -> false in
     List.exists
       (function bs -> match bs with
-      | Bind (mse'',nt'') -> nt_occurs mse''
+      | Bind (loc,mse'',nt'') -> nt_occurs mse''
       | _ -> false)
       (p.prod_bs) in 
 
@@ -533,7 +533,7 @@ let directly_binding_usages_of_this_metavar
   | Empty -> false in
   List.exists
     (function bs -> match bs with
-    | Bind (mse'',nt'') -> mv_occurs mse''
+    | Bind (loc,mse'',nt'') -> mv_occurs mse''
     | _ -> false)
     (p.prod_bs) 
 

--- a/src/system_pp.ml
+++ b/src/system_pp.ml
@@ -110,7 +110,8 @@ let pp_functions_locally_nameless fd m sd xd_transformed =
 let set_locally_nameless m =
   match m with
   | Coq co -> co.coq_locally_nameless := true
-  | _ -> Auxl.error "locally-nameless: only the Coq backend understand {{ repr-locally-nameless }}.\n"
+  (* TODO *)
+  | _ -> Auxl.error None "locally-nameless: only the Coq backend understand {{ repr-locally-nameless }}.\n"
 
 let pp_systemdefn_core_locally_nameless fd m sd lookup = 
   set_locally_nameless m;
@@ -427,7 +428,7 @@ let pp_systemdefn_core_io m sd lookup oi merge_fragments =
   if merge_fragments
   then begin
     let o = match oi with (o,is)::[] -> o 
-    | _ -> Auxl.error "must specify only one output file .\n" in
+    | _ -> Auxl.error None "must specify only one output file .\n" in
     let fn = Auxl.filename_check m o in
     let fd = open_out o in
     pp_systemdefn fd m sd lookup fn;
@@ -450,7 +451,7 @@ let pp_systemdefn_core_io m sd lookup oi merge_fragments =
 			| false -> ["Bool"; "Metatheory"; "List"; "Ott.ott_list_core"]);
         pp_systemdefn_core_locally_nameless fd m sd lookup;
         close_out fd
-    | _ -> Auxl.error "must specify only one output file in the Coq locally-nameless backend.\n" )
+    | _ -> Auxl.error None  "must specify only one output file in the Coq locally-nameless backend.\n" )
 
   else
     begin
@@ -554,7 +555,7 @@ let is_wrap_pre (l,hn,es) = if hn = "tex-wrap-pre" then Some (l,"tex",es) else N
 let is_wrap_post (l,hn,es) = if hn = "tex-wrap-post" then Some (l,"tex",es) else None
 
 let pp_systemdefn_core_tex m sd lookup oi =
-  let xo = match m with | Tex xo -> xo | _ -> Auxl.error "internal: pp_systemdefn_core_tex on non-tex pp_mode\n" in
+  let xo = match m with | Tex xo -> xo | _ -> Auxl.error None "internal: pp_systemdefn_core_tex on non-tex pp_mode\n" in
   match oi with
   | (o,is)::[] ->
       let fd = open_out o in
@@ -623,6 +624,5 @@ let pp_systemdefn_core_tex m sd lookup oi =
         | post_wrap -> Embed_pp.pp_embeds fd m sd.syntax lookup post_wrap
       end;
       close_out fd;
-              
-  | _ -> Auxl.error "must specify only one output file in the TeX backend.\n"
+  | _ -> Auxl.error None "must specify only one output file in the TeX backend.\n"
 

--- a/src/term_parser.ml
+++ b/src/term_parser.ml
@@ -452,7 +452,7 @@ let parse_dots_with_length_constraint length_constraint =
   | None | Some 0 -> f ["..";"...";"...."]
   | Some 1 -> f ["...";"...."]
   | Some 2 -> f ["...."]
-  | _ -> Auxl.error "internal: parse_dots with length_constraint > 2"
+  | _ -> Auxl.error None "internal: parse_dots with length_constraint > 2"
 
 let parse_dots_without_length_constraint =
   let f ds = parse_map (function s -> String.length s - 2)

--- a/src/transform.ml
+++ b/src/transform.ml
@@ -124,7 +124,7 @@ let expand_element (m:pp_mode) (xd:syntaxdefn) (bs:bindspec list) (e:element) :
 	    | Lang_nonterm (ntr,_) -> Some (Ntr (Auxl.promote_ntr xd ntr))
 	    | Lang_metavar (mvr,_) -> Some (Mvr mvr)
             | Lang_terminal t -> None
-	    | _ -> Auxl.error "internal: expand element, cannot happen.\n" )
+	    | _ -> Auxl.error None "internal: expand element, cannot happen.\n" )
 	  elb.elb_es in
 
       let id = (*Auxl.pp_coq_type_name*)
@@ -208,7 +208,7 @@ let expand_element (m:pp_mode) (xd:syntaxdefn) (bs:bindspec list) (e:element) :
 	  | Lang_nonterm (ntr,(ntr',_)) -> Lang_nonterm (ntr,(ntr',[]))
 	  | Lang_metavar (mvr,(mvr',_)) -> Lang_metavar (mvr,(mvr',[])) 
           | Lang_terminal t -> Lang_terminal t
-          | _ -> Auxl.error "internal: remove suffix, cannot happen\n" ) in
+          | _ -> Auxl.error None "internal: remove suffix, cannot happen\n" ) in
 	{ prod_name = "Cons_" ^ id;  
 	  prod_flavour = Bar;
 	  prod_meta = false;

--- a/src/transform.ml
+++ b/src/transform.ml
@@ -151,32 +151,32 @@ let expand_element (m:pp_mode) (xd:syntaxdefn) (bs:bindspec list) (e:element) :
       let rec update_bs bs ss =
         ( match bs with
 
-        | AuxFnDef (f,AuxList (g,(nt,s),b)) :: t ->
+        | AuxFnDef (loc,f,AuxList (g,(nt,s),b)) :: t ->
             if List.mem (Ntr nt) ss   (* FZ add primary? *)
-            then ((AuxFnDef (f,Aux (g,id_nt))), Ic_Aux (g,nt,dummy_ret_type)) :: (update_bs t ss)
-            else ((AuxFnDef (f,AuxList (g,(nt,s),b))), Ic_None) :: (update_bs t ss) 
+            then ((AuxFnDef (loc,f,Aux (g,id_nt))), Ic_Aux (g,nt,dummy_ret_type)) :: (update_bs t ss)
+            else ((AuxFnDef (loc,f,AuxList (g,(nt,s),b))), Ic_None) :: (update_bs t ss) 
 
-        | AuxFnDef (f,NonTermListExp ((ntr,s),b)) :: t -> 
+        | AuxFnDef (loc,f,NonTermListExp ((ntr,s),b)) :: t -> 
             if List.mem (Ntr (Auxl.primary_ntr_of_ntr xd ntr)) ss
-            then ((AuxFnDef (f,Aux (f,id_nt))), Ic_NonTermListExp (f,ntr,dummy_ret_type) ) :: (update_bs t ss)
-            else ((AuxFnDef (f,NonTermListExp ((ntr,s),b))), Ic_None) :: (update_bs t ss) 
+            then ((AuxFnDef (loc,f,Aux (f,id_nt))), Ic_NonTermListExp (f,ntr,dummy_ret_type) ) :: (update_bs t ss)
+            else ((AuxFnDef (loc,f,NonTermListExp ((ntr,s),b))), Ic_None) :: (update_bs t ss) 
 
-        | AuxFnDef (f,MetaVarListExp ((mvr,s),b)) :: t -> 
+        | AuxFnDef (loc,f,MetaVarListExp ((mvr,s),b)) :: t -> 
             if List.mem (Mvr (Auxl.primary_mvr_of_mvr xd mvr)) ss
-            then ((AuxFnDef (f,Aux (f,id_nt))), Ic_MetaVarListExp (f,mvr,dummy_ret_type) ) :: (update_bs t ss)
-            else ((AuxFnDef (f,MetaVarListExp ((mvr,s),b))), Ic_None) :: (update_bs t ss) 
+            then ((AuxFnDef (loc,f,Aux (f,id_nt))), Ic_MetaVarListExp (f,mvr,dummy_ret_type) ) :: (update_bs t ss)
+            else ((AuxFnDef (loc,f,MetaVarListExp ((mvr,s),b))), Ic_None) :: (update_bs t ss) 
 
-        | Bind ((NonTermListExp ((ntr,s),b)), nt) :: t ->  
+        | Bind (loc,(NonTermListExp ((ntr,s),b)), nt) :: t ->  
             let auxfnname= "bind_"^id in
             if List.mem (Ntr (Auxl.primary_ntr_of_ntr xd ntr)) ss
-            then (Bind ((Aux (auxfnname,id_nt)),nt), Ic_NonTermListExp (auxfnname,ntr,Ntr ntr)) :: (update_bs t ss)
-            else (Bind ((NonTermListExp ((ntr,s),b)),nt), Ic_None) :: (update_bs t ss) 
+            then (Bind (loc,(Aux (auxfnname,id_nt)),nt), Ic_NonTermListExp (auxfnname,ntr,Ntr ntr)) :: (update_bs t ss)
+            else (Bind (loc,(NonTermListExp ((ntr,s),b)),nt), Ic_None) :: (update_bs t ss) 
 
-        | Bind ((MetaVarListExp ((mvr,s),b)), nt) :: t ->  
+        | Bind (loc,(MetaVarListExp ((mvr,s),b)), nt) :: t ->  
             let auxfnname= "bind_"^id in
             if List.mem (Mvr (Auxl.primary_mvr_of_mvr xd mvr)) ss
-            then (Bind ((Aux (auxfnname,id_nt)),nt), Ic_MetaVarListExp (auxfnname,mvr,Mvr mvr)) :: (update_bs t ss)
-            else (Bind ((MetaVarListExp ((mvr,s),b)),nt), Ic_None) :: (update_bs t ss) 
+            then (Bind (loc,(Aux (auxfnname,id_nt)),nt), Ic_MetaVarListExp (auxfnname,mvr,Mvr mvr)) :: (update_bs t ss)
+            else (Bind (loc,(MetaVarListExp ((mvr,s),b)),nt), Ic_None) :: (update_bs t ss) 
                 
         | b :: t -> (b,Ic_None)::(update_bs t ss)
         | [] -> [] ) in
@@ -196,9 +196,9 @@ let expand_element (m:pp_mode) (xd:syntaxdefn) (bs:bindspec list) (e:element) :
             ( fun i -> 
               match i with 
               | Ic_None -> None
-              | Ic_Aux (f,_,_) -> Some (AuxFnDef (f,Empty))
-              | Ic_MetaVarListExp (f,_,_) -> Some (AuxFnDef (f,Empty))
-              | Ic_NonTermListExp (f,_,_) -> Some (AuxFnDef (f,Empty)) )
+              | Ic_Aux (f,_,_) -> Some (AuxFnDef (dummy_loc,f,Empty))
+              | Ic_MetaVarListExp (f,_,_) -> Some (AuxFnDef (dummy_loc,f,Empty))
+              | Ic_NonTermListExp (f,_,_) -> Some (AuxFnDef (dummy_loc,f,Empty)) )
             aux_to_def;
 	  prod_loc = dummy_loc } in
 
@@ -223,13 +223,13 @@ let expand_element (m:pp_mode) (xd:syntaxdefn) (bs:bindspec list) (e:element) :
               | Ic_None -> None
               | Ic_Aux (f,nt,_) ->         (* FZ simple suffixes only *)
                   let mse = Union (Aux (f,(nt,[])), Aux (f,id_nt)) in
-                  Some (AuxFnDef (f,mse))
+                  Some (AuxFnDef (dummy_loc,f,mse))
               | Ic_MetaVarListExp (f,mvr,_) -> 
                   let mse = Union ((MetaVarExp (mvr,[])), Aux (f,id_nt) ) in
-                  Some (AuxFnDef (f,mse)) 
+                  Some (AuxFnDef (dummy_loc,f,mse)) 
               | Ic_NonTermListExp (f,ntr,_) -> 
                   let mse = Union ((NonTermExp (ntr,[])), Aux (f,id_nt) ) in
-                  Some (AuxFnDef (f,mse)) )
+                  Some (AuxFnDef (dummy_loc,f,mse)) )
             aux_to_def;
 	  prod_loc = dummy_loc } in
 

--- a/src/types.ml
+++ b/src/types.ml
@@ -977,5 +977,5 @@ let lemTODOmo m s1 s2o = match s2o with None -> None | Some s2 -> Some (lemTODOm
 
 exception Typecheck_error of loc option*string*string;;
 
-let ty_error s1 s2 = raise (Typecheck_error(None, s1,s2))
+(* let ty_error s1 s2 = raise (Typecheck_error(None, s1,s2)) *)
 let ty_error2 l s1 s2 = raise (Typecheck_error(Some l, s1,s2))

--- a/src/types.ml
+++ b/src/types.ml
@@ -292,7 +292,7 @@ and xd_dependencies = (* xddep *)
 and embed = (* embed *)
     embedmorphism 
 
-and parsing_annotation = (prodname*parsing_annotation_type*prodname) (* pa *)
+and parsing_annotation = (prodname*parsing_annotation_type*prodname*loc) (* pa *)
 
 and parsing_annotations = (* pas *)
     { pa_data : parsing_annotation list; }

--- a/src/types.ml
+++ b/src/types.ml
@@ -166,11 +166,11 @@ and dotenv3 = (nt_or_mv*subntr_data) list
 and dotenv = dotenv1 * dotenv2 (* (de1,de2) as de *) 
 
 and bindspec = (* bs *)
-  | Bind of mse * nonterm
-  | AuxFnDef of auxfn * mse
-  | NamesEqual of mse * mse      (* not currently implemented *)
-  | NamesDistinct of mse * mse   (* not currently implemented *)
-  | AllNamesDistinct of mse      (* not currently implemented *)
+  | Bind of loc * mse * nonterm
+  | AuxFnDef of loc * auxfn * mse
+  | NamesEqual of loc * mse * mse      (* not currently implemented *)
+  | NamesDistinct of loc * mse * mse   (* not currently implemented *)
+  | AllNamesDistinct of loc * mse      (* not currently implemented *)
 and mse =  (* mse *) (* mse stands for `metavar set expression', but includes nonterms too *)
   | MetaVarExp of metavar 
   | NonTermExp of nonterm

--- a/src/types.ml
+++ b/src/types.ml
@@ -975,7 +975,7 @@ let lemTODOmo m s1 s2o = match s2o with None -> None | Some s2 -> Some (lemTODOm
 
 (* from grammar_typecheck *)
 
-exception Typecheck_error of string*string;;
+exception Typecheck_error of loc option*string*string;;
 
-let ty_error s1 s2 = raise (Typecheck_error(s1,s2))
-let ty_error2 l s1 s2 = raise (Typecheck_error(s1^" at "^Location.pp_loc l,s2))
+let ty_error s1 s2 = raise (Typecheck_error(None, s1,s2))
+let ty_error2 l s1 s2 = raise (Typecheck_error(Some l, s1,s2))

--- a/src/types.ml
+++ b/src/types.ml
@@ -975,7 +975,7 @@ let lemTODOmo m s1 s2o = match s2o with None -> None | Some s2 -> Some (lemTODOm
 
 (* from grammar_typecheck *)
 
-exception Typecheck_error of loc option*string*string;;
+exception Typecheck_error of loc*string*string;;
 
 (* let ty_error s1 s2 = raise (Typecheck_error(None, s1,s2)) *)
-let ty_error2 l s1 s2 = raise (Typecheck_error(Some l, s1,s2))
+let ty_error2 l s1 s2 = raise (Typecheck_error(l, s1,s2))

--- a/src/types.ml
+++ b/src/types.ml
@@ -473,7 +473,7 @@ type ('t,'v) parser = ('t list -> 'v -> unit) -> 't list -> unit
 
 type made_parser = nontermroot -> bool -> string -> symterm list
 
-exception My_parse_error of string
+exception My_parse_error of loc option * string
 
 
 (** ************************ *)

--- a/src/version.ml
+++ b/src/version.ml
@@ -1,2 +1,2 @@
-let n="0.29"
+let n="0.28"
 let d="Tue Apr 24 06:33:17 CEST 2018"

--- a/src/version.ml
+++ b/src/version.ml
@@ -1,2 +1,2 @@
-let n="0.28"
+let n="0.29"
 let d="Tue Apr 24 06:33:17 CEST 2018"


### PR DESCRIPTION
Currently, Ott presents error messages in a very inconsistent way. The location in the file may be at the beginning or the end of the message, and it isn't clearly delineated from the message of the error. Additionally, a large number of errors contained no location information.

I've gone through and revamped the error message presentation, ensuring that all use the same format and adding locations to almost every error.

Now, error messages have the following format:

```
File filename on loc:
Error: error message text
```
For example:
```
File ../tests/test10st.ott on line 55, column 7 - 81:
Warning: Free variables in hom element [[G2]]
```
Having a consistent format should make it easier to parse error messages for editors like emacs and vscode. 

Error messages now include color if the `-color` option is enabled on the terminal.

To attach a location to (nearly) every error, the `error` and `warning` functions from `Auxl` now take a `loc Option` parameter, and a few of the data structures and helper functions have a location added.

The function `ty_error` has been commented out, since `ty_error2` is now used everywhere in `grammar_typecheck.ml, meaning every type error has a location attached to it.
