### PR TITLE
Bring support for comments in Isabelle 2018.

### DIFF
--- a/src/grammar_pp.ml
+++ b/src/grammar_pp.ml
@@ -1396,7 +1396,7 @@ and pp_com_es m xd homs es =
       pp_tex_COM_NAME m  ^"{"
       ^ String.concat "" (apply_hom_spec m xd hs ((*List.map (function s -> "$"^s^"$")*) ss))
       ^ "}" 
-    | Isa _ -> " -- {* " ^ String.concat "" (apply_hom_spec m xd hs ss) ^ " *}"
+    | Isa _ -> " \<comment> \<open>" ^ String.concat "" (apply_hom_spec m xd hs ss) ^ "\<close>"
     | Coq _ -> " (*r " ^ String.concat "" (apply_hom_spec m xd hs ss) ^ " *)" 
     | Hol _ | Lem _ | Caml _ | Lex _ ->  " (* " ^ String.concat "" (apply_hom_spec m xd hs ss) ^ " *)" 
     | Rdx _ -> "  ;; " ^ String.concat "" (apply_hom_spec m xd hs ss) 
@@ -1412,7 +1412,7 @@ and pp_com_strings m xd homs ss =
       pp_tex_COM_NAME m  ^"{"
       ^ String.concat "" (apply_hom_spec m xd hs (List.map (function s -> "$"^s^"$") ss))
       ^ "}"
-    | Isa _ -> " -- {* " ^ String.concat "" (apply_hom_spec m xd hs ss) ^ " *}"
+    | Isa _ -> " \<comment> \<open>" ^ String.concat "" (apply_hom_spec m xd hs ss) ^ "\<close>"
     | Coq _ -> " (*r " ^ String.concat "" (apply_hom_spec m xd hs ss) ^ " *)"
     | Hol _ | Lem _ | Caml _ | Lex _ ->  " (* " ^ String.concat "" (apply_hom_spec m xd hs ss) ^ " *)"
     | Rdx _ ->  " ;; " ^ String.concat "" (apply_hom_spec m xd hs ss)


### PR DESCRIPTION
Since Isabelle 2018, the support for `-- {* ... *}` style comments has been removed and `\<comment> \<open> ... \<close>` is mandatory [1]. This commit makes Ott generate such comments by default.

Any Isabelle version that supports the new style of comments, including 2017, is still supported with this change.

[1] http://isabelle.in.tum.de/dist/Isabelle2018/doc/NEWS.html