### PR TITLE
Fix list bounds when subrules are present

### DIFF
--- a/regression/config.otr
+++ b/regression/config.otr
@@ -25,4 +25,4 @@
 + + . + + + ../tests/test17.12.ott
 + + . + + + ../tests/test17.11.ott
 + + . + + + ../tests/test17.10.ott
-+ + + + + + ../tests/test_list_subrules.ott
++ + . . . + ../tests/test_list_subrules.ott

--- a/regression/config.otr
+++ b/regression/config.otr
@@ -25,3 +25,4 @@
 + + . + + + ../tests/test17.12.ott
 + + . + + + ../tests/test17.11.ott
 + + . + + + ../tests/test17.10.ott
++ + + + + + ../tests/test_list_subrules.ott

--- a/regression/regression.otl
+++ b/regression/regression.otl
@@ -99,3 +99,4 @@ sys-purercdsub : ../examples/tapl/common.ott ../examples/tapl/common_typing.ott 
 ../tests/test_embed_top_1.ott
 ../tests/test_merge_embed_location_1-1.ott
 ../tests/test_merge_embed_location_1-2.ott
+../tests/test_list_subrules.ott

--- a/src/bounds.ml
+++ b/src/bounds.ml
@@ -324,10 +324,27 @@ let dotenv23 ntmvsn_without_bounds ntmvsn_with_bounds  =
   de2,de3
 
 
+let coalesce_bounds x : ((Types.nt_or_mv * Types.subntr_data) * Types.bound option) list =
+  let merge_data d1 d2 = d1
+  in let merge_bounds b1 b2 = match (b1, b2) with
+      | (None, b) -> b
+      | (b, None) -> b
+      | (Some b1, Some b2) ->
+        if b1 == b2 then (Some b1) else
+          raise (Bounds ("incompatible bounds " ))
+  in let names = Auxl.remove_duplicates (List.map (fun ((a,b),c) -> a) x)
+  in let namesMatching nm =  List.filter (fun  ((ntmv, _),_) -> ntmv == nm) x
+  in let merge_pairs ((nm,d1),b1) ((_,d2),b2) =
+       ((nm, merge_data d1 d2), merge_bounds b1 b2)
+  in List.map (fun nm ->
+       let matching = (namesMatching nm )
+       in List.fold_right merge_pairs matching (List.hd matching)) names
+
 
 let bound_extraction m xd loc sts : dotenv * dotenv3 * string = 
   try  
-    let x = nt_or_mv_of_symterms sts in
+    let x_unc =  nt_or_mv_of_symterms sts in
+    let x = coalesce_bounds x_unc in
     let bounds = check_length_consistency x in
     let pp_bounds = String.concat "  " 
         (List.map Grammar_pp.pp_plain_bound bounds) in

--- a/tests/test_list_subrules.ott
+++ b/tests/test_list_subrules.ott
@@ -1,0 +1,44 @@
+% Mixing list bounds with subrules
+% Should pass on all targets, but previous versions failed
+% in Coq with "The variable tau_ is bound several times in pattern"
+% due to an error in how bound were calculated for sub-non-terminals
+
+metavar var, X ::= {{coq nat}} {{isa nat}} {{hol nat}} {{ocaml int}}
+
+indexvar n ::=  {{coq nat}} {{isa nat}} {{hol nat}} {{ocaml int}}
+
+grammar
+
+Kind, K :: kind_ ::= 
+  | KindStar :: :: KindStar 
+ 
+typexpr, T :: T_ ::=                  
+    | X                   ::   :: var                     
+    | ForAll << X1 , .. , Xn >> .  T            ::   :: polyarrow
+    |  [ X1 |-> tau1 .. Xn |-> taun ] T        :: M :: tsub  {{icho  [[T]]  }}
+
+tau :: tau_ ::=    
+    | X                   ::   :: var   
+    
+    formula :: 'formula_' ::=
+      | judgement           ::   :: judgement
+      | formula1 .. formulan :: :: dots
+
+    subrules
+      tau <:: T
+
+    defns
+      Jtype :: '' ::=
+
+    defn
+        |- T : K :: :: kind :: Kind by
+       
+        ------------------------------------ :: Var
+        |- T : KindStar
+
+    defn
+        |- T <: T' :: :: sub :: Sub by
+ 
+        </ |-  taun : KindStar // n />
+        ------------------------------------------ :: InstL
+        |-  ForAll << </ Xn // n /> >> .  T  <: [ </ Xn |-> taun // n /> ] T 

--- a/tests/test_list_subrules.ott
+++ b/tests/test_list_subrules.ott
@@ -3,9 +3,9 @@
 % in Coq with "The variable tau_ is bound several times in pattern"
 % due to an error in how bound were calculated for sub-non-terminals
 
-metavar var, X ::= {{coq nat}} {{isa nat}} {{hol nat}} {{ocaml int}}
+metavar var, X ::= {{coq nat}} 
 
-indexvar n ::=  {{coq nat}} {{isa nat}} {{hol nat}} {{ocaml int}}
+indexvar n ::=  {{coq nat}}
 
 grammar
 


### PR DESCRIPTION
This adds a "bounds-coalescing" function to bounds.ml, which addresses the bug in #26, namely that nonterminals were appearing multiple times in produced lists, since they were being assigned non-matching bounds.

All tests in the regression suite show the same behaviour on my machine before and after the changes.