### PR TITLE
Coq library is compatible with Coq 8.9

### DIFF
--- a/coq-ott.opam
+++ b/coq-ott.opam
@@ -10,7 +10,7 @@ license: "part BSD3, part LGPL 2.1"
 build: [ make "-j%{jobs}%" "-C" "coq" ]
 install: [ make "-C" "coq" "install" ]
 remove: [ "sh" "-c" "rm -rf '%{lib}%/coq/user-contrib/Ott'" ]
-depends: [ "coq" {(>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~") | (>= "8.7" & < "8.8~") | (>= "8.8" & < "8.9~")} ]
+depends: [ "coq" {(>= "8.5" & < "8.6~") | (>= "8.6" & < "8.7~") | (>= "8.7" & < "8.8~") | (>= "8.8" & < "8.9~") | (>= "8.9" & < "8.10~")} ]
 
 tags: [
   "category:Computer Science/Semantics and Compilation/Semantics"


### PR DESCRIPTION
The coq-ott package successfully compiles with the latest release of
Coq (version 8.9.0).