### PR TITLE
[Doc] Replace shell backticks by bash $() and add LaTeX packages required by Pandoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ directory                | description
 
 If you have [OPAM](https://opam.ocaml.org) installed on your system,
 `opam install ott` will install the latest Ott version.  The Emacs mode
-will be in `` `opam config var prefix`/share/emacs/site-lisp ``, and
-documentation in `` `opam config var prefix`/doc/ott ``.
+will be in `` $(opam config var prefix)/share/emacs/site-lisp ``, and
+documentation in `` $(opam config var prefix)/doc/ott ``.
 
 To install the Ott auxiliary files for Coq, first activate the
 `coq-released` OPAM repository:

--- a/doc/top2.mng
+++ b/doc/top2.mng
@@ -8,7 +8,11 @@
 \usepackage{alltt}
 \usepackage{hevea}
 \usepackage[usenames]{color}
- 
+\usepackage{hyperref}
+\usepackage{booktabs}
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}} % For pandoc lists
+
 %\usepackage{ctable} %for pandoc-generated table
 \newcommand{\ctable}[1][]{}
 \newcommand{\FL}{\begin{center}\begin{tabular}{ll}}


### PR DESCRIPTION
I did not manage to compile Ott documentation without these two modifications (with Pandoc version 2.2.1).