### PR TITLE
fix hint database deprecations in Coq library

### DIFF
--- a/coq/ott_list_core.v
+++ b/coq/ott_list_core.v
@@ -28,7 +28,7 @@ Inductive Exists_list (P:A->Prop) : list A -> Prop :=
   | Exists_tail : forall x l, Exists_list P l -> Exists_list P (x::l).
 
 End list_predicates.
-Hint Constructors Forall_list Exists_list.
+Hint Constructors Forall_list Exists_list : core.
 
 
 

--- a/coq/ott_list_predicate.v
+++ b/coq/ott_list_predicate.v
@@ -21,7 +21,7 @@ Set Implicit Arguments.
 
 Lemma not_Exists_list_nil : forall P, ~(Exists_list P nil).
 Proof. intros P H; inversion H. Qed.
-Hint Resolve not_Exists_list_nil.
+Hint Resolve not_Exists_list_nil : core.
 
 Lemma Forall_list_dec :
   forall P (dec : forall x, {P x} + {~P x}) l,
@@ -87,7 +87,7 @@ Proof.
   intros; induction l; simpl in * . assumption.
   inversion_clear H. auto.
 Qed.
-Hint Resolve app_Forall_list Forall_list_app_left Forall_list_app_right.
+Hint Resolve app_Forall_list Forall_list_app_left Forall_list_app_right : core.
 
 Lemma Exists_list_app_or :
   forall P l l', Exists_list P (l++l') ->
@@ -107,7 +107,7 @@ Lemma app_Exists_list_right :
 Proof.
   intros; induction l; simpl; auto.
 Qed.
-Hint Resolve Exists_list_app_or app_Exists_list_left app_Exists_list_right.
+Hint Resolve Exists_list_app_or app_Exists_list_left app_Exists_list_right : core.
 
 Lemma rev_Forall_list :
   forall P l, Forall_list P l -> Forall_list P (rev l).

--- a/coq/ott_list_support.v
+++ b/coq/ott_list_support.v
@@ -28,7 +28,7 @@ Section functions.
   Definition compose (g:B->C) (f:A->B) x := g (f x).
   Definition compose2 (h:B->C->D) (f:A->B) (g:A->C) x y := h (f x) (g y).
 End functions.
-Hint Unfold compose compose2.
+Hint Unfold compose compose2 : core.
 
 
 
@@ -50,4 +50,4 @@ Section option.
     end.
   Definition fold_error := fold_option.
 End option.
-Hint Unfold map_option map_error fold_option fold_error.
+Hint Unfold map_option map_error fold_option fold_error : core.


### PR DESCRIPTION
This is an uncontroversial Coq library fix (for Coq 8.10) that's completely backwards compatible.