### PR TITLE
Fix HOL library compatibility with kananaskis-13

### DIFF
--- a/hol/.gitignore
+++ b/hol/.gitignore
@@ -1,0 +1,5 @@
+*.ui
+*.uo
+*Theory.*
+.HOLMK
+.hollogs

--- a/hol/Makefile
+++ b/hol/Makefile
@@ -3,3 +3,4 @@ all:
 
 clean:
 	rm -f *Theory.* *.ui *.uo
+	rm -rf .HOLMK .hollogs

--- a/hol/ottScript.sml
+++ b/hol/ottScript.sml
@@ -7,7 +7,7 @@ val list_minus_def = Define
  (list_minus (x::xs) ys = (if ~(MEM x ys) then x::(list_minus xs ys) else list_minus xs ys))`;
 
 val list_minus_thm = Q.store_thm ("list_minus_thm",
-`!l x. MEM x (list_minus l l') = MEM x l /\ ~MEM x l'`,
+`!l x. MEM x (list_minus l l') = (MEM x l /\ ~MEM x l')`,
 Induct THEN RW_TAC list_ss [list_minus_def] THEN METIS_TAC []);
 
 val list_minus_append = Q.store_thm ("list_minus_append",
@@ -20,7 +20,9 @@ val list_assoc_def = Define
 
 val list_assoc_mem = Q.store_thm ("list_assoc_mem",
 `!l x y. (list_assoc x l = SOME y) ==> MEM (x,y) l`,
-Induct THEN FULL_SIMP_TAC list_ss [list_assoc_def] THEN Cases_on `h` THEN RW_TAC list_ss [list_assoc_def]);
+Induct THEN RW_TAC list_ss [list_assoc_def] THEN
+Cases_on `h` THEN RW_TAC list_ss [list_assoc_def] THEN
+Cases_on `x = q` THEN FULL_SIMP_TAC list_ss [list_assoc_def]);
 
 val list_assoc_not_mem = Q.store_thm ("list_assoc_not_mem",
 `!l x y. (list_assoc x l = NONE) ==> ~MEM (x,y) l`,
@@ -67,7 +69,7 @@ val mono_every_id_thm = Q.store_thm ("mono_every_id_thm",
 `(!x. P x ==> Q x) ==> EVERY (\x. x) (MAP P l) ==> EVERY (\x. x) (MAP Q l)`,
 Induct_on `l` THEN RW_TAC list_ss [] THEN METIS_TAC []);
 
-val _ = IndDefLib.export_mono "mono_every_id_thm"
+val _ = IndDefLib.export_mono "mono_every_id_thm";
 
 val filter_size = Q.store_thm ("filter_size",
 `!l f size. list_size size (FILTER f l) <= list_size size l`,

--- a/revision_history.txt
+++ b/revision_history.txt
@@ -526,3 +526,7 @@ hack when it's hom
 2019-08 @hannesm update opam file to 2.0
 
 2019-08-01 Version 0.29
+
+2019-10 @palmskog fix Coq library deprecations with Coq 8.10
+
+2019-11 @palmskog HOL library compatibility with kananaskis-13 and master


### PR DESCRIPTION
We are aiming to use Ott (and Lem) for various tasks in the [HolBA](https://github.com/kth-step/HolBA) project. To this end, here's a small update to the Ott HOL library to make it compile in kananaskis-13. I've also tested it with HOL4 `master` as of November 2019.