### PR TITLE
Fix broken link to binding & substitution note

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ As of 2020, Ott remains in continuous use.
   (html)](http://www.cl.cam.ac.uk/~pes20/ott/top2.html)
 
 - [Binding and
-  Substitution](http://www.cl.cam.ac.uk/users/pes20/bind-doc.pdf). Susmit
+  Substitution](http://www.cl.cam.ac.uk/users/pes20/ott/bind-doc.pdf). Susmit
   Sarkar, Peter Sewell, Francesco Zappa Nardelli.  Note, 2007.
 
 - [The experimental Coq locally-nameless backend


### PR DESCRIPTION
There is now an `/ott/` subdir, which I guessed based on the html docs link. There may be other broken links too!