### PR TITLE
coq-ott compatible with Coq 8.14

### DIFF
--- a/coq/.gitignore
+++ b/coq/.gitignore
@@ -5,6 +5,7 @@
 *.glob
 *.v.d
 *.aux
+.lia.cache
 Makefile.coq
 Makefile.coq.conf
 .Makefile.coq.d

--- a/coq/_CoqProject
+++ b/coq/_CoqProject
@@ -12,5 +12,3 @@ ott_list_nth.v
 ott_list_core.v
 ott_list_distinct.v
 ott_list_flat_map.v
-
--arg -w -arg -omega-is-deprecated

--- a/coq/ott_list_base.v
+++ b/coq/ott_list_base.v
@@ -2,7 +2,7 @@
 
 Require Import Arith.
 Require Import List.
-Require Import Omega.
+Require Import Lia.
 Require Import Wf_nat.
 Require Import Ott.ott_list_support.
 
@@ -113,7 +113,7 @@ Lemma app_inj_suffix_length_prefix :
 Proof.
   intros. eapply app_inj_prefix_length_prefix. 2: eexact H0.
   assert (Eq := f_equal (@length A) H0).
-  repeat rewrite length_app in Eq. omega.
+  repeat rewrite length_app in Eq. lia.
 Qed.
 Lemma app_inj_suffix_length_suffix :
   forall l0 l1 l0' l1',

--- a/coq/ott_list_distinct.v
+++ b/coq/ott_list_distinct.v
@@ -8,7 +8,7 @@ Require Import Ott.ott_list_core.
 Require Import Ott.ott_list_base.
 Require Import Ott.ott_list_nth.
 Require Import Ott.ott_list_mem.
-Require Import Omega.
+Require Import Lia.
 
 
 
@@ -164,15 +164,15 @@ Proof.
   generalize (j-i); clear Ineq j; intros k Distinct Nths Bound.
   destruct k. solve [auto with arith]. elimtype False.
   generalize dependent xs; induction i; intros; destruct xs; simpl in * .
-  omega.
+  lia.
   destruct (andb_prop2 _ _ Distinct) as [Notin _]; clear Distinct Bound.
   generalize dependent k; induction xs; intros; simpl in * .
   destruct k; discriminate.
   destruct (eq_dec a0 a). exact Notin.
   destruct k; simpl in *; [injection Nths | idtac]; solve [eauto].
-  omega.
+  lia.
   eapply IHi; eauto. destruct_andb; assumption.
-  omega.
+  lia.
 Qed.
 Lemma all_distinct_indices :
   forall xs i j,
@@ -183,7 +183,7 @@ Lemma all_distinct_indices :
 Proof.
   intros. destruct (le_ge_dec i j).
   eapply all_distinct_indices_aux; eauto.
-  symmetry. eapply all_distinct_indices_aux; eauto. omega.
+  symmetry. eapply all_distinct_indices_aux; eauto. lia.
 Qed.
 
 End All_distinct.

--- a/coq/ott_list_nth.v
+++ b/coq/ott_list_nth.v
@@ -1,5 +1,5 @@
 Require Import Arith.
-Require Import Omega.
+Require Import Lia.
 Require Import List.
 Require Import Ott.ott_list_support.
 Require Import Ott.ott_list_base.
@@ -92,8 +92,8 @@ Lemma nth_error_out :
   forall l n, length l <= n -> nth_error l n = error.
 Proof.
   induction l; intros n H. solve [apply nth_error_nil].
-  simpl in H. destruct n. assert False; [omega | intuition].
-  simpl. apply IHl. omega.
+  simpl in H. destruct n. assert False; [lia | intuition].
+  simpl. apply IHl. lia.
 Qed.
 
 Lemma nth_error_app_prefix :
@@ -128,7 +128,7 @@ Proof.
     destruct (le_lt_dec (length l) n);
     destruct (le_lt_dec (S (length l)) (S n));
     reflexivity ||
-    (assert False; [omega | intuition]) ||
+    (assert False; [lia | intuition]) ||
     simpl.
   match match goal with |- ?g => g end with value ?lhs = value ?rhs =>
     assert (Eq : lhs=rhs)
@@ -162,11 +162,10 @@ Lemma nth_eq_nth_safe :
                       end.
 Proof.
   induction l; destruct n; reflexivity || intros. simpl nth; simpl length.
-  destruct (le_lt_dec (S (length l)) (S n));
-    case_eq (le_lt_dec (length l) n); intros;
-    [idtac | elimtype False; omega | elimtype False; omega | idtac];
-    pose (H' := IHl n default); rewrite H in H'; rewrite H'.
-  reflexivity. simpl; apply nth_safe_proof_irrelevance.
+  rewrite (IHl n default).
+  simpl; destruct (le_lt_dec (length l) n); simpl.
+  reflexivity.
+  apply nth_safe_proof_irrelevance.
 Qed.
 
 Lemma nth_eq_nth_error :
@@ -189,6 +188,6 @@ Arguments nth_safe_app [A] _ _ _ _.
 
 Hint Rewrite nth_map nth_ok_map nth_error_map : lists.
 Hint Rewrite nth_error_nil : lists.
-Hint Rewrite nth_error_in nth_error_out using omega : list_nth_error.
+Hint Rewrite nth_error_in nth_error_out using lia : list_nth_error.
 Hint Rewrite nth_error_dec : list_nth_dec.
 Hint Resolve nth_error_value nth_error_error : datatypes.

--- a/coq/ott_list_repeat.v
+++ b/coq/ott_list_repeat.v
@@ -2,7 +2,7 @@
 
 Require Import Arith.
 Require Import List.
-Require Import Omega.
+Require Import Lia.
 Require Import Ott.ott_list_support.
 Require Import Ott.ott_list_base.
 Require Import Ott.ott_list_nth.
@@ -43,7 +43,7 @@ Qed.
 
 Lemma repeat_S : forall n x, repeat (S n) x = repeat n x ++ x::nil.
 Proof.
-  intros. replace (S n) with (n+1). 2: omega.
+  intros. replace (S n) with (n+1). 2: lia.
   rewrite repeat_app. reflexivity.
 Qed.
 
@@ -71,7 +71,7 @@ Proof.
   intros. assert (value (nth_safe (repeat n x) m H) = value x).
   rewrite nth_safe_eq_nth_error. rewrite nth_error_repeat.
   rewrite repeat_length in H.
-  destruct (le_lt_dec n m). elimtype False; omega. reflexivity.
+  destruct (le_lt_dec n m). lia. reflexivity.
   injection H0. tauto.
 Qed.
 

--- a/coq/ott_list_support.v
+++ b/coq/ott_list_support.v
@@ -1,7 +1,7 @@
 (* Additional definitions and lemmas on lists *)
 
 Require Import Arith.
-Require Import Omega.
+Require Import Lia.
 
 
 
@@ -15,7 +15,7 @@ Lemma le_lt_dec_S :
     (if le_lt_dec n m then x else y).
 Proof.
   intros. destruct (le_lt_dec n m); destruct (le_lt_dec (S n) (S m)).
-  reflexivity. elimtype False; omega. elimtype False; omega. reflexivity.
+  reflexivity. lia. lia. reflexivity.
 Qed.
 
 End List_lib_Arith.

--- a/coq/ott_list_takedrop.v
+++ b/coq/ott_list_takedrop.v
@@ -4,7 +4,7 @@ Require Import Arith.
 Require Import Max.
 Require Import Min.
 Require Import List.
-Require Import Omega.
+Require Import Lia.
 Require Import Ott.ott_list_support.
 Require Import Ott.ott_list_base.
 Require Import Ott.ott_list_nth.
@@ -47,7 +47,7 @@ Lemma take_all :
 Proof.
   induction l; destruct n; intros; try reflexivity.
   solve [inversion H].
-  simpl in * . apply (f_equal2 (@cons A)). reflexivity. apply IHl. omega.
+  simpl in * . apply (f_equal2 (@cons A)). reflexivity. apply IHl. lia.
 Qed.
 
 Lemma take_length :
@@ -101,7 +101,7 @@ Lemma drop_all :
 Proof.
   induction l; destruct n; intros; try reflexivity.
   solve [inversion H].
-  simpl in * . apply IHl. omega.
+  simpl in * . apply IHl. lia.
 Qed.
 
 Lemma drop_length : forall l n, length (drop n l) = length l - n.
@@ -120,7 +120,7 @@ Proof.
   generalize (conj (refl_equal (length (drop n l))) (refl_equal (drop n l))).
   pattern (drop n l) at 1 3.
   case (drop n l); intros; rewrite drop_length in H; destruct H; simpl in * .
-  elimtype False; omega.
+  lia.
   rewrite <- H0. assumption.
 Qed.
 
@@ -193,7 +193,7 @@ Proof. intros. induction l; simpl; congruence. Qed.
 Lemma take_from_app :
   forall l l', take (length l) (l ++ l') = l.
 Proof.
-  intros. replace (length l) with (length l + 0). 2: omega.
+  intros. replace (length l) with (length l + 0). 2: lia.
   rewrite take_app_short. rewrite take_0.
   symmetry. apply app_nil_end.
 Qed.
@@ -201,7 +201,7 @@ Qed.
 Lemma drop_from_app :
   forall l l', drop (length l) (l ++ l') = l'.
 Proof.
-  intros. replace (length l) with (length l + 0). 2: omega.
+  intros. replace (length l) with (length l + 0). 2: lia.
   rewrite drop_app_short. apply drop_0.
 Qed.
 
@@ -267,7 +267,7 @@ Ltac cut_list original cut_point prefix suffix :=
       autorewrite with lists take_drop; intros;
       rename p into prefix; rename s into suffix
     | (**length original < n**)
-      try (equate_list_lengths; elimtype False; omega) ]
+      try (equate_list_lengths; lia) ]
   ).
 
 (* Look for equations between lists that can be simplified.
@@ -280,14 +280,14 @@ Ltac parallel_split :=
              | H : app ?p ?s = app ?p' ?s' |- _ =>
                (
                  assert (tmp : length p = length p');
-                   [equate_list_lengths; omega | idtac];
+                   [equate_list_lengths; lia | idtac];
                  assert (EqPrefix := app_inj_prefix_length_prefix _ _ _ _ tmp H);
                  rewrite <- EqPrefix in H;
                  assert (EqSuffix := app_inj_prefix _ _ _ H);
                  clear tmp H
                ) || (
                  assert (tmp : length s = length s');
-                   [equate_list_lengths; omega | idtac];
+                   [equate_list_lengths; lia | idtac];
                  assert (EqSuffix := app_inj_prefix_length_suffix _ _ _ _ tmp H);
                  rewrite <- EqSuffix in H;
                  assert (EqPrefix := app_inj_suffix _ _ _ H);
@@ -303,7 +303,7 @@ Ltac parallel_split_maps :=
   repeat match goal with
            | H : map ?f ?p ++ map ?f ?s = ?p' ++ ?s' |- _ =>
              assert (Eqlen' : length (map f p) = length p');
-               [equate_list_lengths; omega | idtac];
+               [equate_list_lengths; lia | idtac];
              assert (EqPrefix := app_inj_prefix_length_prefix _ _ _ _ Eqlen' H);
              rewrite <- EqPrefix in H;
              assert (EqSuffix := app_inj_prefix _ _ _ H);


### PR DESCRIPTION
Omega has been removed and replaced with Lia in Coq 8.14. **NB: I haven't tested this patch with other versions of Coq yet.**