### PR TITLE
Enable automated testing of the OCaml code generation

### DIFF
--- a/ott.opam
+++ b/ott.opam
@@ -7,10 +7,15 @@ homepage: "http://www.cl.cam.ac.uk/~pes20/ott/"
 bug-reports: "https://github.com/ott-lang/ott/issues"
 depends: [
   "ocaml" {>= "4.02.0"}
+  "pprint" {with-test & < "20220103"}
+  "menhir" {with-test}
 ]
 build: [
   [make "world"]
   [make "ott.install"]
+]
+run-test: [
+  [make "-C" "tests/menhir_tests/test_if"]
 ]
 dev-repo: "git+https://github.com/ott-lang/ott.git"
 synopsis: "A tool for writing definitions of programming languages and calculi"

--- a/tests/menhir_tests/test_if/Makefile
+++ b/tests/menhir_tests/test_if/Makefile
@@ -12,7 +12,7 @@ MENHIR          := menhir
 
 MENHIRFLAGS     := --infer --explain --unused-tokens --trace --base $(ROOT)_parser
 
-OCAMLBUILD      := ocamlbuild -use-ocamlfind -use-menhir -menhir "$(MENHIR) $(MENHIRFLAGS) ../$(MENHIR_EXTRA_LIB) "
+OCAMLBUILD      := ocamlbuild -use-ocamlfind -use-menhir -menhir "$(MENHIR) $(MENHIRFLAGS) ../$(MENHIR_EXTRA_LIB) " -package pprint
 
 MAIN            := main
 


### PR DESCRIPTION
As https://github.com/ott-lang/ott/pull/88 has shown, the generated code can be broken.

This time around, @fpottier realized `ott` used an incompatible interface: https://github.com/ocaml/opam-repository/pull/20363
However in the general case, it would be great to have this automated in opam-repository’s CI. Currently no tests are ran and issues would not be discovered, but this PR would solve this issue.