### PR TITLE
minimal _CoqProject change to enable compatibility with Coq 8.17

### DIFF
--- a/coq/_CoqProject
+++ b/coq/_CoqProject
@@ -1,5 +1,8 @@
 -Q . Ott
 
+-arg -w -arg -deprecated-hint-without-locality
+-arg -w -arg -deprecated-hint-rewrite-without-locality
+
 ott_list_predicate.v
 ott_list_takedrop.v
 ott_list.v


### PR DESCRIPTION
@tperami we have Coq 8.17.0 coming out in the not-too-distant future. After #96 is merged, OK with you to do a new Ott release supporting both Coq 8.17.0 and OCaml 5?  

(We have high hopes of Ott use increasing among Coq users due to its inclusion in the [Coq Platform](https://github.com/coq/platform/).)