### PR TITLE
Fix Stack_overflow for filtering a file

### DIFF
--- a/src/term_parser.ml
+++ b/src/term_parser.ml
@@ -1219,7 +1219,7 @@ let make_parser xd : made_parser =
             None -> []
           | Some tree -> 
               let res = P.process_parse_tree tree in
-                List.map (fun (Ntp.Gtp.Res_st s) -> s) res
+                List.rev (List.rev_map (fun (Ntp.Gtp.Res_st s) -> s) res)
   in
   new_parser;;
 


### PR DESCRIPTION
The current implementation rarely raises the Stack_overflow exception for filtering some particular files.  I encountered the situation with a file containing a rather long `[[ ... ]]` being parsed. 

This fix replaces non-tail-recursive functions related to the problem with tail-recursive ones.  I believe this fix causes minor performance issues for at least filtering files the current implementation can handle because only a short list is dealt with in such cases.  The fix may be more efficient if we well understand the algorithm, though.  For example, we can remove `List.rev` if a list used in the algorithm is order-irrespective.