### PR TITLE
Fix opam build on Windows (MinGW cygwin cross)

### DIFF
--- a/ott.opam
+++ b/ott.opam
@@ -16,6 +16,9 @@ depends: [
 build: [
   [make "world"] { ocaml:native }
   [make "world.byt"] { !ocaml:native }
+  ["rm" "src/ott"] {os = "win32"}
+  ["cp" "src/ott.opt" "src/ott"] {os = "win32" & ocaml:native}
+  ["cp" "src/ott.byte" "src/ott"] {os = "win32" & !ocaml:native}
   [make "ott.install"]
 ]
 run-test: [


### PR DESCRIPTION
This PR fixes the opam file, so that it builds on Windows, when symlinks are not supported (the usual case).

The MinGW opam repo had a corresponding fix for 0.32 here:

https://github.com/ocaml-opam/opam-repository-mingw/tree/sunset/packages/ott/ott.0.32

but not for 0.33.

I pushed fixes for 0.32 and 0.33 to the main opam repo as well (the MinGW repo is deprecated) in PR:

https://github.com/ocaml/opam-repository/pull/24942

@palmskog : FYI.