### PR TITLE
Added support for UTF-8

### DIFF
--- a/src/grammar_lexer.mll
+++ b/src/grammar_lexer.mll
@@ -199,22 +199,24 @@ let get_first_word_and_rest =
 let go_back n f lexbuf =
   lexbuf.Lexing.lex_curr_pos <- lexbuf.Lexing.lex_curr_pos - n;
   my_lexer_state := f
-
 } 
 
+(* remember: these codepoints are in decimal, not octal *)
 let whitespace = (' ' | '\t' | '\010' | '\012' | '\013')
 let newline = ('\010' | '\013' | "\013\010")
 let non_newline = [^ '\010' '\013']
 let non_newline_whitespace = (' ' | '\t' |'\012')
-(* let pre_ident = (['A'-'Z'] | ['a'-'z'] | ['0'-'9'] | "_" | "'")(['A'-'Z'] | ['a'-'z'] | ['0'-'9'] | "_" | "-" | "'")* *)
-let pre_ident = (['A'-'Z'] | ['a'-'z'] | ['0'-'9'] | "_" | "'")(['A'-'Z'] | ['a'-'z'] | ['0'-'9'] | "_" | "'")*
-let maybe_quoted_ident = pre_ident | ("'" pre_ident "'" ) | "''"
+(* Note: the bit at the end allows all Unicode which is not special ASCII characters *)
+let pre_ident = (['A'-'Z'] | ['a'-'z'] | ['0'-'9'] | "_" | "'" | ['\128'-'\255'])+
+let maybe_quoted_ident = pre_ident
 (*
 let pre_ident_allow_minus = (['A'-'Z'] | ['a'-'z'] | ['0'-'9'] | "_" | "'")(['A'-'Z'] | ['a'-'z'] | ['0'-'9'] | "_" | "-" | "'")*
 let maybe_quoted_ident_allow_minus = pre_ident_allow_minus | ("'" pre_ident_allow_minus "'" ) | "''"
 *)
 let string = [^ ' '  '\t'  '\010'  '\012'  '\013']+
-
+(* UNICODE NOTES: The above regexes will parse unicode whitespace as identifiers. This is the same
+as what the "string" regex would do in some positions previously, and the "whitespace" regex is not
+Unicode-aware, so we view this as not breaking anything new. Nonetheless, caveat emptor. *)
 
 (* We use context-dependent lexing, lexing (eg) the elements of a *)
 (* production w.r.t. a small language so that the user rarely has to *)

--- a/tests/test10_unicode.ott
+++ b/tests/test10_unicode.ott
@@ -1,0 +1,45 @@
+metavar var, x ::=   {{ com  term variable }} 
+{{ isa string}} {{ coq nat}} {{ hol string}} {{ lem string }} {{ coq-equality }}
+{{ ocaml int}} {{ lex alphanum}} {{ tex \mathit{[[var]]} }}
+
+grammar
+项 {{tex \tau}}, t :: 't_' ::=                               {{ com term    }}
+  | x            ::   :: var                   {{ com variable}}
+  | λ x . t      ::   :: lam (+ bind x in t +) {{ com lambda  }}
+  | t t'         ::   :: app                   {{ com app     }}
+  | ( t )        :: S :: paren                 {{ icho [[t]]  }}  {{ lem [[t]] }}
+  | { t / x } t' :: M :: sub  
+                         {{ icho (tsubst_term [[t]] [[x]] [[t']])}}
+  {{ lem (tsubst_term [[t]] [[x]] [[t']]) }}
+val,v :: 'v_' ::=                            {{ com value   }}
+  | λ x . t      ::   :: lam                   {{ com lambda  }}
+
+terminals :: 'terminals_' ::=
+  | λ            ::   :: lambda  {{ tex \lambda }}
+  | -->          ::   :: red     {{ tex \longrightarrow }}
+
+subrules
+  val <:: 项
+
+substitutions
+  single 项 var :: tsubst 
+
+defns
+Jop :: '' ::=
+
+ defn
+ t1 --> t2 :: ::reduce::'' {{ com $[[t1]]$ reduces to $[[t2]]$ }} {{ lemwcf  witness type reduce_witness; check reduce_check; eval : input -> output }} by
+
+
+    --------------------------  :: ax_app
+    (λx.t1) v2 -->  {v2/x}t1
+
+    t1 --> t1'
+    -------------- :: ctx_app_fun
+    t1 t --> t1' t
+
+    t1 --> t1'
+    -------------- :: ctx_app_arg
+    v t1 --> v t1'
+
+

--- a/tests/test17.12_unicode.ott
+++ b/tests/test17.12_unicode.ott
@@ -1,0 +1,136 @@
+% test17.12.ott  sundry list form test
+
+embed
+{{ coq 
+(** some concrete labels *)
+Definition LA : nat := 1.
+Definition LB : nat := 2.
+Definition LC : nat := 3.
+}}
+
+metavar typevar, X ::=
+ {{ isa string }} {{ coq nat }} {{ coq-equality }} {{ hol string }} {{ lex Alphanum }}  
+ {{ tex \mathit{[[typevar]]} }} {{ com  type variable  }}  
+ {{ isavar ''[[typevar]]'' }} {{ texvar \mathrm{[[typevar]]} }} 
+
+metavar termvar, x ::=
+ {{ isa string }} {{ coq nat }} {{ hol string }}  {{ coq-equality }} {{ lex alphanum }}  
+ {{ tex \mathit{[[termvar]]} }} {{ com  term variable  }} 
+ {{ isavar ''[[termvar]]'' }} {{ texvar \mathrm{[[termvar]]} }} 
+
+metavar label, l, k ::=
+ {{ isa string }} {{ coq nat }} {{ hol string }} {{ lex alphanum }}  {{ tex \mathit{[[label]]} }}  {{ isavar ''[[label]]'' }} {{ holvar "[[label]]" }}
+ {{ com  field label  }}
+
+indexvar index, i, j, n, m  ::= {{ isa nat }} {{ coq nat }} {{ hol num }} {{ lex numeral }}
+  {{ com indices }}
+
+
+grammar
+
+T {{ hol Typ }}, S, U :: 'T_' ::=                    {{ com type  }}
+  | X                                :: :: Var          {{ com type variable }}  
+  | { l1 : T1 , .. , ln : Tn }      :: :: Rec           {{ com record }}           
+  | [ l0 : T0 , .. , ln-1 : Tn-1 ]      :: :: ZRec           {{ com record }}           
+  | int :: :: int
+  | bool :: :: bool
+
+t :: 't_' ::=                                                      {{ com  term  }}
+  | x                                     :: :: Var                 {{ com variable }}         
+%  | { l1 = t1 ,  .. , ln = tn }           :: :: Rec             {{ com record  --- dots }}
+%  | { </ li = ti // i /> }                :: :: Rec_comp_none   {{ com record --- comp }}
+%  | { </ li = ti // , // i /> }           :: :: Rec_comp_some   {{ com record --- comp with terminal }}
+%  | { </ li = ti // i IN n /> }           :: :: Rec_comp_u_none {{ com record --- compu }} 
+%  | { </ li = ti // , // i IN n /> }      :: :: Rec_comp_u_some {{ com record --- compu with terminal }} 
+%  | { </ li = ti // i IN 1 .. n /> }      :: :: Rec_comp_lu_none{{ com record --- complu }}  
+  | { </ li = ti // , // i IN 1 .. n /> } :: :: Rec_comp_lu_some {{ com record --- complu with terminal }}  
+  | [ </ li = ti // , // i IN 0 .. n-1 /> ] :: :: ZRec_comp_lu_some {{ com record --- complu with terminal }}  
+  | t . l                             :: :: Proj                     {{ com projection }} 
+  | true                              :: :: True {{ com True }}
+  | false                             :: :: False {{ com False }}
+
+Γ {{ tex \Gamma }}, Δ {{ tex \Delta }} :: 'G_' ::= {{ com type environment }}
+  | empty                            ::   :: empty       
+  | Γ , X <: T                       ::   :: type        
+  | Γ , x : T                        ::    :: term
+%  | Γ , Γ'                           :: M :: comma    {{ ich TODO }}
+%  | Γ1 , .. , Γn                     :: M :: dots {{ ich TODO }}
+
+
+formula :: formula_ ::=          
+  | judgement              :: :: judgement
+  | formula1 .. formulan   :: :: dots 
+%{{ isa (List.list_all (\<lambda> b . b) ( [[ formula1 .. formulan ]] ) ) }}
+
+%formula :: formula_ ::=          
+%  | preformula1 .. preformulan   :: :: realdots {{ isa (List.list_all (\<lambda> b . b) ( [[ preformula1 .. preformulan ]] ) ) }}
+
+terminals :: terminals_ ::=
+  | |-                     ::   :: turnstile {{ tex \vdash }}
+  | <:                     ::   :: subtype   {{ tex <: }}
+
+defns
+  Jtype :: '' ::= 
+
+defn
+Γ |- t : T ::  :: Ty :: Ty_  {{ com term $[[t]]$ has type $[[T]]$ }} by 
+
+ Γ|-t0:T0 .. Γ|- tn-1 : Tn-1
+ ------------------------------------- :: Rcd_dotform
+ Γ|- {l0=t0,..,ln-1=tn-1}:{l0:T0,..,ln-1:Tn-1}
+ 
+ Γ|- t:{l0:T0,..,ln-1:Tn-1}
+ ----------------------- :: Proj_dotform
+ Γ|- t.lj : Tj
+
+
+ </ Γ|-ti:Ti //i/>
+ -------------------------------------- :: Rcd_comp
+ Γ|- { </li=ti//i/> }:{ </ li:Ti //i/> }
+
+ Γ|- t: { </ li:Ti // i/> }
+ -------------------------------------- :: Proj_comp
+ Γ|- t.lj : Tj
+
+ </ Γ|-ti:Ti //i IN n/>
+ -------------------------------------------------- :: Rcd_comp_u
+ Γ|- { </li=ti//i IN n/> }:{ </ li:Ti //i IN n/> }
+
+ Γ|- t: { </ li:Ti // i IN n/> }
+ -------------------------------------------------- :: Proj_comp_u
+ Γ|- t.lj : Tj
+
+ </ Γ|-ti:Ti //i IN 0..n-1/>
+ ------------------------------------------------------- :: Rcd_comp_lu
+ Γ|- { </li=ti//i IN 0..n-1/> }:{ </ li:Ti //i IN 0..n-1/> }
+
+ Γ|- t: { </ li:Ti // i IN 0..n-1/> }
+ ------------------------------------------------------- :: Proj_comp_lu
+ Γ|- t.lj : Tj
+
+
+ Γ |- x : { l_0:T_0 ,.., l_n-1:T_n-1 }
+ --------------- :: foo
+ Γ |- x : { li0:Ti0 ,.., lin-1:Tin-1 }
+
+
+defn
+|- T ::  :: Tyfoo :: Tyfoo_ by 
+
+|- { } 
+|- { LA:int }
+|- { LA:int, LB:bool }
+|- { LA:int, LB:bool, LC : bool }
+|- { l1:T1,..,lm:Tm }
+|- { l:T , l1:T1,..,lm:Tm }
+|- { l1:T1,..,lm:Tm, l:T }
+|- { l1:T1,..,lm:Tm,l:T,l1':T1',..,ln':Tn' }
+--------------------------------------------- :: 1
+ |- int
+
+|- { </ li:Ti // i IN 1..m /> }
+|- { l:T , </ li:Ti // i IN 1..m /> }
+|- { </ li:Ti // i IN 1..m /> , l:T }
+|- { </ li:Ti // i IN 1..m /> ,l:T, </ l'j:T'j // j IN 1..n /> }
+-------------------------------- :: 2
+|- int


### PR DESCRIPTION
Some design decisions:

- Nonterminals can now be any UTF-8 strings which do not contain any ASCII special characters, which are defined to be all ASCII characters (i.e. with codepoint ≤ 127) other than `['0'-'9']|['a'-'z']|['A'-'Z']`
- Nonterminals with Unicode names are escaped into TeX by mapping codepoints to base-16 shifted up by 16, i.e. with digits ghijklmnopqrstuv. So λ2, which is at codepoint 03bb, becomes `\ottjrrTwo` (with the default prefix `\ott`).
- Invalid UTF-8 leads to an exception being thrown