### PR TITLE
Compatibility with Coq 8.19 and later, modernize Coq code

### DIFF
--- a/coq-ott.opam
+++ b/coq-ott.opam
@@ -17,7 +17,7 @@ this library.
 build: [make "-j%{jobs}%" "-C" "coq"]
 install: [make "-C" "coq" "install"]
 depends: [
-  "coq" {>= "8.5"}
+  "coq" {>= "8.14"}
 ]
 tags: [
   "category:Computer Science/Semantics and Compilation/Semantics"

--- a/coq/Makefile
+++ b/coq/Makefile
@@ -1,14 +1,16 @@
-default: Makefile.coq
-	$(MAKE) -f Makefile.coq
+all: Makefile.coq
+	@+$(MAKE) -f Makefile.coq all
 
-install: Makefile.coq
-	$(MAKE) -f Makefile.coq install
+clean: Makefile.coq
+	@+$(MAKE) -f Makefile.coq cleanall
+	@rm -f Makefile.coq Makefile.coq.conf
 
 Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o Makefile.coq
 
-clean: Makefile.coq
-	$(MAKE) -f Makefile.coq cleanall
-	rm -f Makefile.coq Makefile.coq.conf
+force _CoqProject Makefile: ;
 
-.PHONY: default clean install
+%: Makefile.coq force
+	@+$(MAKE) -f Makefile.coq $@
+
+.PHONY: all clean force

--- a/coq/_CoqProject
+++ b/coq/_CoqProject
@@ -1,8 +1,5 @@
 -Q . Ott
 
--arg -w -arg -deprecated-hint-without-locality
--arg -w -arg -deprecated-hint-rewrite-without-locality
-
 ott_list_predicate.v
 ott_list_takedrop.v
 ott_list.v

--- a/coq/ott_list.v
+++ b/coq/ott_list.v
@@ -1,36 +1,36 @@
-(* A supplemental list library to help ott users *)
+(** * Supplemental list library to help ott users *)
 
-(* Definitions used by ott-generated output *)
+(** Definitions used by ott-generated output *)
 Require Export Ott.ott_list_core.
 
-(* Support library (non-list-related content) *)
+(** Support library (non-list-related content) *)
 Require Export Ott.ott_list_support.
 
-(* Supplemental lemmas and tactics about basic functions (length, map, rev) *)
+(** Supplemental lemmas and tactics about basic functions (length, map, rev) *)
 Require Export Ott.ott_list_base.
 
-(* The take and drop functions, and lemmas and tactics about them
-   (n = take n l ++ drop n l) /\ (length (take n l) = n) *)
+(** The [take] and [drop] functions, and lemmas and tactics about them, such as
+ [(n = take n l ++ drop n l) /\ (length (take n l) = n)] *)
 Require Export Ott.ott_list_takedrop.
 
-(* Supplemental lemmas about taking the nth element of a list *)
+(** Supplemental lemmas about taking the nth element of a list *)
 Require Export Ott.ott_list_nth.
 
-(* Lemmas about [In], [list_mem] and [list_minus] *)
+(** Lemmas about [In], [list_mem] and [list_minus] *)
 Require Export Ott.ott_list_mem.
 
-(* Lemmas about [flat_map] *)
+(** Lemmas about [flat_map] *)
 Require Export Ott.ott_list_flat_map.
 
-(* Lemmas and tactics about [Forall_list], [Exists_list], [forall_list]
+(** Lemmas and tactics about [Forall_list], [Exists_list], [forall_list]
    and [exists_list] *)
 Require Export Ott.ott_list_predicate.
 
-(* The repeat function, and lemmas about it
-   (length (repeat n x) = n) /\ (forall y, In y (repeat n x) -> x = y) *)
+(** The [repeat] function, and lemmas about it, such as
+   [(length (repeat n x) = n) /\ (forall y, In y (repeat n x) -> x = y)] *)
 Require Export Ott.ott_list_repeat.
 
-(* The [disjoint] function (test that two lists have no common element),
+(** The [disjoint] function (test that two lists have no common element),
    the [all_distinct] function (test that a list has no repeated element),
    and lemmas about them *)
 Require Export Ott.ott_list_distinct.

--- a/coq/ott_list_base.v
+++ b/coq/ott_list_base.v
@@ -1,4 +1,4 @@
-(* Additional definitions and lemmas on lists *)
+(** * Additional definitions and lemmas on lists *)
 
 Require Import Arith.
 Require Import List.
@@ -6,9 +6,7 @@ Require Import Lia.
 Require Import Wf_nat.
 Require Import Ott.ott_list_support.
 
-
-
-(*** Tactic definitions ***)
+(** ** Tactics *)
 
 (* Tactic definitions do not survive their section, so tactics that are
    exported must come outside of any section. *)
@@ -21,9 +19,7 @@ Ltac reverse_list l l' :=
        clearbody tmp; subst l; rename tmp into l']
   ).
 
-
-
-(*** Start of the Lists section ***)
+(** ** Definitions and lemmas *)
 
 Section Lists.
 
@@ -39,10 +35,7 @@ Implicit Types g : B -> C.
 Implicit Types m n : nat.
 Set Implicit Arguments.
 
-
-
-
-(*** Length ***)
+(** *** Length *)
 
 Definition lt_length (A:Type) := ltof _ (@length A).
 Definition well_founded_lt_length (A:Type) := (well_founded_ltof _ (@length A)).
@@ -52,10 +45,7 @@ Proof.
   induction l; simpl; auto.
 Qed.
 
-
-
-
-(*** Reverse ***)
+(** *** Reverse **)
 
 Lemma length_rev : forall l, length (rev l) = length l.
 Proof.
@@ -71,9 +61,7 @@ Proof.
   apply (f_equal (@rev A)). assumption.
 Qed.
 
-
-
-(*** Concatenation ***)
+(** *** Concatenation *)
 
 Lemma rev_app : forall l l', rev (l++l') = rev l' ++ rev l.
 Proof (@distr_rev A).
@@ -123,9 +111,7 @@ Proof.
   eapply app_inj_prefix; eauto.
 Qed.
 
-
-
-(*** Map ***)
+(** *** Map *)
 
 Lemma length_map : forall f l, length (map f l) = length l.
 Proof.
@@ -174,12 +160,10 @@ Proof.
   simpl. rewrite map_app. rewrite IHl. reflexivity.
 Qed.
 
-
-
-(*** End of the Lists section ***)
-
 End Lists.
 Arguments lt_length [A] _ _.
+
+(** ** Hints and more tactics *)
 
 #[export] Hint Resolve length_app length_map length_rev : datatypes.
 #[export] Hint Rewrite length_app length_map length_rev : lists.
@@ -192,9 +176,7 @@ Arguments lt_length [A] _ _.
              app_inj_suffix_length_prefix app_inj_suffix_length_suffix
              app_inj_prefix app_inj_suffix : app_inj.
 
-
-
-(* Look for equations in the context that prove that some lists are empty,
+(** Look for equations in the context that prove that some lists are empty,
    and substitute them away. *)
 Ltac eliminate_nil :=
   repeat
@@ -206,13 +188,13 @@ Ltac eliminate_nil :=
       | H : ?l = nil |- _ => subst l
     end.
 
-(* Simplify all hypotheses involving the list [l]. *)
+(** Simplify all hypotheses involving the list [l]. *)
 Ltac simplify_list l :=
   generalize dependent l; intro;
   autorewrite with lists; unfold compose; simpl;
   intros.
 
-(* Simplify all hypotheses involving lists. *)
+(** Simplify all hypotheses involving lists. *)
 Ltac simplify_lists :=
   repeat match goal with l:list _ |- _ =>
            generalize dependent l; intro;
@@ -221,7 +203,7 @@ Ltac simplify_lists :=
          end;
   intros.
 
-(* For every hypothesis that is an equality between lists, add a hypothesis
+(** For every hypothesis that is an equality between lists, add a hypothesis
    stating that their lengths are equal. *)
 Ltac equate_list_lengths :=
   let eq' := fresh "eq" in (
@@ -234,4 +216,3 @@ Ltac equate_list_lengths :=
     unfold eq' in *; clear eq';
     autorewrite with lists; simpl; intros
   ).
-

--- a/coq/ott_list_base.v
+++ b/coq/ott_list_base.v
@@ -60,7 +60,7 @@ Qed.
 Lemma length_rev : forall l, length (rev l) = length l.
 Proof.
   induction l; auto.
-  simpl. rewrite length_app. rewrite IHl. simpl. rewrite plus_comm. auto.
+  simpl. rewrite length_app. rewrite IHl. simpl. rewrite Nat.add_comm. auto.
 Qed.
 
 Definition rev_rev := rev_involutive.

--- a/coq/ott_list_base.v
+++ b/coq/ott_list_base.v
@@ -181,14 +181,14 @@ Qed.
 End Lists.
 Arguments lt_length [A] _ _.
 
-Hint Resolve length_app length_map length_rev : datatypes.
-Hint Rewrite length_app length_map length_rev : lists.
-Hint Rewrite rev_app rev_unit rev_rev : lists.
-Hint Rewrite <- app_assoc : lists.
-Hint Rewrite app_nil_r : lists.
-Hint Rewrite <- app_comm_cons.
-Hint Rewrite map_app map_map map_rev map_identity : lists.
-Hint Rewrite app_inj_prefix_length_prefix app_inj_prefix_length_suffix
+#[export] Hint Resolve length_app length_map length_rev : datatypes.
+#[export] Hint Rewrite length_app length_map length_rev : lists.
+#[export] Hint Rewrite rev_app rev_unit rev_rev : lists.
+#[export] Hint Rewrite <- app_assoc : lists.
+#[export] Hint Rewrite app_nil_r : lists.
+#[export] Hint Rewrite <- app_comm_cons.
+#[export] Hint Rewrite map_app map_map map_rev map_identity : lists.
+#[export] Hint Rewrite app_inj_prefix_length_prefix app_inj_prefix_length_suffix
              app_inj_suffix_length_prefix app_inj_suffix_length_suffix
              app_inj_prefix app_inj_suffix : app_inj.
 

--- a/coq/ott_list_base.v
+++ b/coq/ott_list_base.v
@@ -184,8 +184,9 @@ Arguments lt_length [A] _ _.
 Hint Resolve length_app length_map length_rev : datatypes.
 Hint Rewrite length_app length_map length_rev : lists.
 Hint Rewrite rev_app rev_unit rev_rev : lists.
-Hint Rewrite app_ass : lists.
-Hint Rewrite <- app_nil_end app_comm_cons : lists.
+Hint Rewrite <- app_assoc : lists.
+Hint Rewrite app_nil_r : lists.
+Hint Rewrite <- app_comm_cons.
 Hint Rewrite map_app map_map map_rev map_identity : lists.
 Hint Rewrite app_inj_prefix_length_prefix app_inj_prefix_length_suffix
              app_inj_suffix_length_prefix app_inj_suffix_length_suffix

--- a/coq/ott_list_core.v
+++ b/coq/ott_list_core.v
@@ -1,28 +1,28 @@
-(* Definitions that are used by ott-generated output (when using non-expanded lists) *)
+(** * Definitions used by ott-generated output (when using non-expanded lists) *)
 
 Require Import Bool.
 Require Import List.
+
 Set Implicit Arguments.
-
-
 
 Section list_predicates.
 Variable (A : Type).
 
-(* Test whether a predicate [p] holds for every element of a list [l]. *)
+(** Test whether a predicate [p] holds for every element of a list [l]. *)
 Definition forall_list (p:A->bool) (l:list A) :=
   fold_left (fun b (z:A) => b && p z) l true.
 
-(* Test whether a predicate [p] holds for some element of a list [l]. *)
+(** Test whether a predicate [p] holds for some element of a list [l]. *)
 Definition exists_list (p:A->bool) (l:list A) :=
   fold_left (fun b (z:A) => b || p z) l false.
 
-(* Assert that a property holds for every element of a list *)
+(** Assert that a property holds for every element of a list. *)
 Inductive Forall_list (P:A->Prop) : list A -> Prop :=
   | Forall_nil : Forall_list P nil
   | Forall_cons :
     forall x l, P x -> Forall_list P l -> Forall_list P (x::l).
-(* Assert that a property holds for some element of a list *)
+
+(** Assert that a property holds for some element of a list. *)
 Inductive Exists_list (P:A->Prop) : list A -> Prop :=
   | Exists_head : forall x l, P x -> Exists_list P (x::l)
   | Exists_tail : forall x l, Exists_list P l -> Exists_list P (x::l).
@@ -30,22 +30,20 @@ Inductive Exists_list (P:A->Prop) : list A -> Prop :=
 End list_predicates.
 #[export] Hint Constructors Forall_list Exists_list : core.
 
-
-
 Section list_mem.
-(* Functions about membership in a list, with equality between a list
+(** Functions about membership in a list, with equality between a list
    element and a potential member being decided by [eq_dec]. *)
 Variable (A : Type).
 Variable (eq_dec : forall (a b:A), {a=b} + {a<>b}).
 
-(* Test whether [x] appears in [l]. *)
+(** Test whether [x] appears in [l]. *)
 Fixpoint list_mem (x:A) (l:list A) {struct l} : bool :=
   match l with
   | nil => false
   | cons h t => if eq_dec h x then true else list_mem x t
 end.
 
-(* Remove any element of [l1] that is present in [l2]. *)
+(** Remove any element of [l1] that is present in [l2]. *)
 Fixpoint list_minus (l1 l2:list A) {struct l1} : list A :=
   match l1 with
   | nil => nil
@@ -54,18 +52,17 @@ Fixpoint list_minus (l1 l2:list A) {struct l1} : list A :=
 end.
 End list_mem.
 
-
-
 Section Flat_map_definition.
 Variables (A B : Type).
 Variable (f : A -> list B).
-(* This definition is almost the same as the one in the standard library of
+
+(** This definition is almost the same as the one in the standard library of
    Coq V8.0 or V8.1. The difference is that this version has the shape
-    fun A B f => (fix flat_map l := _)
+    [fun A B f => (fix flat_map l := _)]
    while the standard library has
-    fun A B => (fix flat_map f l := _)
+    [fun A B => (fix flat_map f l := _)]
    Our version has the advantage of making recursive definitions such as
-    fix foo x := match x with ... | List xs => flat_map foo xs end
+    [fix foo x := match x with ... | List xs => flat_map foo xs end]
    well-founded.
  *)
 Fixpoint flat_map (l:list A) {struct l} : list B :=
@@ -75,7 +72,5 @@ Fixpoint flat_map (l:list A) {struct l} : list B :=
   end.
 End Flat_map_definition.
 
-
-
-(* Provide helper lemmas for {{coq-equality}} homs. *)
+(** Provide helper lemmas for [{{coq-equality}}] homs. *)
 Require Export Ott.ott_list_eq_dec.

--- a/coq/ott_list_core.v
+++ b/coq/ott_list_core.v
@@ -28,7 +28,7 @@ Inductive Exists_list (P:A->Prop) : list A -> Prop :=
   | Exists_tail : forall x l, Exists_list P l -> Exists_list P (x::l).
 
 End list_predicates.
-Hint Constructors Forall_list Exists_list : core.
+#[export] Hint Constructors Forall_list Exists_list : core.
 
 
 

--- a/coq/ott_list_distinct.v
+++ b/coq/ott_list_distinct.v
@@ -162,7 +162,7 @@ Proof.
   intros xs i j Ineq.
   replace j with (i + (j-i)). 2: solve [auto with arith].
   generalize (j-i); clear Ineq j; intros k Distinct Nths Bound.
-  destruct k. solve [auto with arith]. elimtype False.
+  destruct k. solve [auto with arith]. exfalso.
   generalize dependent xs; induction i; intros; destruct xs; simpl in * .
   lia.
   destruct (andb_prop2 _ _ Distinct) as [Notin _]; clear Distinct Bound.

--- a/coq/ott_list_distinct.v
+++ b/coq/ott_list_distinct.v
@@ -1,4 +1,4 @@
-(*** Lists with no repetition ***)
+(** * Lists with no repetition *)
 
 Require Import Arith.
 Require Import Bool.
@@ -9,8 +9,6 @@ Require Import Ott.ott_list_base.
 Require Import Ott.ott_list_nth.
 Require Import Ott.ott_list_mem.
 Require Import Lia.
-
-
 
 Section All_distinct.
 Set Implicit Arguments.
@@ -24,13 +22,12 @@ Fixpoint all_distinct (xs:list A) : bool :=
     | nil => true
     | x::xt => andb (one_distinct x xt) (all_distinct xt)
   end.
+
 Fixpoint disjoint (xs ys:list A) {struct xs} : bool :=
   match xs with
     | nil => true
     | x::xt => andb (one_distinct x ys) (disjoint xt ys)
   end.
-
-
 
 Ltac destruct_andb :=
   repeat match goal with
@@ -47,6 +44,7 @@ Proof.
   induction xs; simpl in * . reflexivity.
   destruct (eq_dec a x0); simpl in *; congruence.
 Qed.
+
 Lemma disjoint_eq_fold_right :
   forall xs ys,
     disjoint xs ys = fold_right (fun x => andb (one_distinct x ys)) true xs.
@@ -59,6 +57,7 @@ Proof.
   intros; induction xs; simpl in * . reflexivity.
   destruct (eq_dec a x); auto with bool.
 Qed.
+
 Lemma all_distinct_app :
   forall xs ys,
     all_distinct (xs++ys) =
@@ -76,12 +75,14 @@ Proof.
   simplify_lists. apply Is_true_eq_left. assert (H' := Is_true_eq_true _ H).
   unfold negb in * . destruct (list_mem eq_dec x xs); auto.
 Qed.
+
 Lemma all_distinct_app_left :
   forall xs ys, Is_true (all_distinct (xs++ys)) -> Is_true (all_distinct xs).
 Proof.
   intros. rewrite all_distinct_app in H.
   destruct_andb; assumption.
 Qed.
+
 Lemma one_distinct_app_right :
   forall x xs ys,
     Is_true (one_distinct x (xs++ys)) -> Is_true (one_distinct x xs).
@@ -90,6 +91,7 @@ Proof.
   simplify_lists. apply Is_true_eq_left. assert (H' := Is_true_eq_true _ H).
   unfold negb in * . destruct (list_mem eq_dec x xs); auto.
 Qed.
+
 Lemma all_distinct_app_right :
   forall xs ys, Is_true (all_distinct (xs++ys)) -> Is_true (all_distinct xs).
 Proof.
@@ -99,8 +101,10 @@ Qed.
 
 Lemma disjoint_nil_left : forall xs, disjoint nil xs = true.
 Proof. reflexivity. Qed.
+
 Lemma disjoint_nil_right : forall xs, disjoint xs nil = true.
 Proof. induction xs; simpl; congruence. Qed.
+
 Lemma disjoint_comm :
   forall xs ys, disjoint xs ys = disjoint ys xs.
 Proof.
@@ -111,12 +115,14 @@ Proof.
   destruct (eq_dec a0 a); destruct (eq_dec a a0); try subst a0.
   reflexivity. elim n; reflexivity. elim n; reflexivity. ring.
 Qed.
+
 Lemma disjoint_app_distr_left :
   forall xs ys zs, disjoint xs (ys++zs) = disjoint xs ys && disjoint xs zs.
 Proof.
   intros. induction xs; simpl in * . reflexivity.
   rewrite IHxs; rewrite one_distinct_app. ring.
 Qed.
+
 Lemma disjoint_app_distr_right :
   forall xs ys zs, disjoint (xs++ys) zs = disjoint xs zs && disjoint ys zs.
 Proof.
@@ -131,18 +137,21 @@ Proof.
   rewrite one_distinct_app; rewrite IHxs; simpl.
   destruct (eq_dec a x); ring.
 Qed.
+
 Lemma rev_disjoint_right :
   forall xs ys, disjoint xs (rev ys) = disjoint xs ys.
 Proof.
   intros; induction xs; simpl in * . reflexivity.
   rewrite rev_one_distinct; rewrite IHxs; reflexivity.
 Qed.
+
 Lemma rev_disjoint_left :
   forall xs ys, disjoint (rev xs) ys = disjoint xs ys.
 Proof.
   intros; induction xs; simpl in * . reflexivity.
   rewrite disjoint_app_distr_right; simpl. rewrite IHxs; ring.
 Qed.
+
 Lemma rev_all_distinct :
   forall xs, all_distinct (rev xs) = all_distinct xs.
 Proof.
@@ -174,6 +183,7 @@ Proof.
   eapply IHi; eauto. destruct_andb; assumption.
   lia.
 Qed.
+
 Lemma all_distinct_indices :
   forall xs i j,
     Is_true (all_distinct xs) ->

--- a/coq/ott_list_distinct.v
+++ b/coq/ott_list_distinct.v
@@ -190,8 +190,8 @@ End All_distinct.
 
 Notation one_distinct := (fun eq_dec x xs => negb (list_mem eq_dec x xs)).
 
-Hint Rewrite one_distinct_app all_distinct_app : lists.
-Hint Rewrite disjoint_nil_left disjoint_nil_right : lists.
-Hint Rewrite disjoint_app_distr_left disjoint_app_distr_right : lists.
-Hint Rewrite rev_one_distinct rev_disjoint_right rev_disjoint_left
+#[export] Hint Rewrite one_distinct_app all_distinct_app : lists.
+#[export] Hint Rewrite disjoint_nil_left disjoint_nil_right : lists.
+#[export] Hint Rewrite disjoint_app_distr_left disjoint_app_distr_right : lists.
+#[export] Hint Rewrite rev_one_distinct rev_disjoint_right rev_disjoint_left
              rev_all_distinct : lists.

--- a/coq/ott_list_eq_dec.v
+++ b/coq/ott_list_eq_dec.v
@@ -1,11 +1,9 @@
-(* Helper lemmas for {{coq-equality}} homs. *)
+(** * Helper lemmas for coq-equality homs *)
 
 Require Import List.
 Set Implicit Arguments.
 
-
-
-(* Help construct equality decision procedures (for {{coq-equality}}
+(** Help construct equality decision procedures (for [{{coq-equality}}]
    homs). We provide a transparent version of [List.list_eq_dec] from
    the Coq standard library. This transparent version is needed for
    types that contain a recursive call inside a list. Note that at the
@@ -26,7 +24,7 @@ Proof.
   apply e; injection H; trivial.
 Defined.
 
-(* While the Coq built-in "decide equality" tactic can decide equality on
+(** While the Coq built-in "decide equality" tactic can decide equality on
    pairs on its own, adding the following lemmas in the hint database helps
    when lists of pairs are involved. *)
 Lemma pair_eq_dec :
@@ -37,8 +35,7 @@ Lemma pair_eq_dec :
 Proof. intros until 2; decide equality; auto. Qed.
 #[export] Hint Resolve pair_eq_dec : ott_coq_equality.
 
-(* With the following hint, the default {{coq-equality}} proof handles
+(** With the following hint, the default [{{coq-equality}}] proof handles
    grammar types containing lists provided that no recursive call appears
    in a list. *)
 #[export] Hint Resolve list_eq_dec : ott_coq_equality.
-

--- a/coq/ott_list_eq_dec.v
+++ b/coq/ott_list_eq_dec.v
@@ -35,10 +35,10 @@ Lemma pair_eq_dec :
          (eqB:forall b b0:B, {b=b0}+{b<>b0})
          (x y:A*B), {x=y}+{x<>y}.
 Proof. intros until 2; decide equality; auto. Qed.
-Hint Resolve pair_eq_dec : ott_coq_equality.
+#[export] Hint Resolve pair_eq_dec : ott_coq_equality.
 
 (* With the following hint, the default {{coq-equality}} proof handles
    grammar types containing lists provided that no recursive call appears
    in a list. *)
-Hint Resolve list_eq_dec : ott_coq_equality.
+#[export] Hint Resolve list_eq_dec : ott_coq_equality.
 

--- a/coq/ott_list_flat_map.v
+++ b/coq/ott_list_flat_map.v
@@ -87,10 +87,10 @@ Qed.
 
 End Flat_map.
 
-Hint Rewrite std_eq_flat_map
+#[export] Hint Rewrite std_eq_flat_map
              length_flat_map flat_map_app flat_map_map map_flat_map
              flat_map_identity flat_map_extensionality
              flat_map_rev
              unfold_flatten
              : lists.
-Hint Resolve In_flat_map_intro In_flat_map_elim : lists.
+#[export] Hint Resolve In_flat_map_intro In_flat_map_elim : lists.

--- a/coq/ott_list_flat_map.v
+++ b/coq/ott_list_flat_map.v
@@ -1,12 +1,10 @@
-(*** Flattening and mapping ***)
+(** * Flattening and mapping on lists *)
 
 Require Import Arith.
 Require Import List.
 Require Import Ott.ott_list_core.
 Require Import Ott.ott_list_support.
 Require Import Ott.ott_list_base.
-
-
 
 Section Flat_map.
 Variables A B C : Type.
@@ -65,6 +63,7 @@ Proof.
 Qed.
 
 Definition flatten := flat_map (fun xs => xs).
+
 Lemma unfold_flatten : flatten = flat_map (fun xs => xs).
 Proof refl_equal _.
 

--- a/coq/ott_list_mem.v
+++ b/coq/ott_list_mem.v
@@ -1,4 +1,4 @@
-(*** Membership predicates ***)
+(** * Membership predicates on lists *)
 
 Require Import Arith.
 Require Import Bool.
@@ -7,19 +7,18 @@ Require Import Ring.
 Require Import Ott.ott_list_base.
 Require Import Ott.ott_list_core.
 Require Import Ott.ott_list_nth.
+
 Set Implicit Arguments.
 
-
-
-(*** Membership predicate ***)
+(** ** Membership predicate *)
 
 Section In.
 Variable A : Type.
 Implicit Types x : A.
 Implicit Types xs l : list A.
 
-(* Speed up proofs by providing trivial consequences of [List.in_or_app] that
-   do not require eauto. *)
+(** Speed up proofs by providing trivial consequences of [in_or_app] that
+   do not require [eauto]. *)
 Lemma In_left_app :
   forall l l' a, In a l -> In a (l ++ l').
 Proof. auto with datatypes. Qed.
@@ -53,9 +52,7 @@ End In.
 #[export] Hint Resolve not_in_app_or not_in_or_app : datatypes.
 #[export] Hint Resolve nth_error_In nth_safe_In : datatypes.
 
-
-
-(*** Membership predicate and map ***)
+(** ** Membership predicate and map *)
 
 Lemma image_In_map :
   forall (A B:Type) x l (f:A->B),
@@ -88,9 +85,7 @@ Ltac elim_all_In_map :=
              )
          end.
 
-
-
-(*** Membership function ***)
+(** ** Membership function *)
 
 Section list_mem.
 Variable A : Type.
@@ -164,9 +159,7 @@ End list_mem.
 
 #[export] Hint Rewrite list_mem_app : lists.
 
-
-
-(*** Removing an element ***)
+(** ** Removing an element *)
 
 Section list_minus.
 Variable A : Type.

--- a/coq/ott_list_mem.v
+++ b/coq/ott_list_mem.v
@@ -49,9 +49,9 @@ Qed.
 
 End In.
 
-Hint Resolve In_left_app In_right_app : datatypes.
-Hint Resolve not_in_app_or not_in_or_app : datatypes.
-Hint Resolve nth_error_In nth_safe_In : datatypes.
+#[export] Hint Resolve In_left_app In_right_app : datatypes.
+#[export] Hint Resolve not_in_app_or not_in_or_app : datatypes.
+#[export] Hint Resolve nth_error_In nth_safe_In : datatypes.
 
 
 
@@ -162,7 +162,7 @@ Proof. intros; apply In_implies_list_mem. apply nth_safe_In; auto. Qed.
 
 End list_mem.
 
-Hint Rewrite list_mem_app : lists.
+#[export] Hint Rewrite list_mem_app : lists.
 
 
 
@@ -201,5 +201,5 @@ Qed.
 
 End list_minus.
 
-Hint Resolve In_list_plus : In_list_plus.
-Hint Resolve In_list_minus_other : datatypes.
+#[export] Hint Resolve In_list_plus : In_list_plus.
+#[export] Hint Resolve In_list_minus_other : datatypes.

--- a/coq/ott_list_mem.v
+++ b/coq/ott_list_mem.v
@@ -148,7 +148,7 @@ Proof.
     repeat match goal with |- context C [In_dec ?eq_dec_ ?x_ ?l_] =>
              destruct (In_dec eq_dec_ x_ l_)
            end;
-    intros; try ring; elimtype False;
+    intros; try ring; exfalso;
     (let a := type of i in (generalize dependent i; fold (~a)));
     auto with datatypes.
 Qed.

--- a/coq/ott_list_nth.v
+++ b/coq/ott_list_nth.v
@@ -186,8 +186,8 @@ Arguments nth_safe_proof_irrelevance [A] _ _ _ _.
 Arguments nth_safe_cons [A] _ _ _ _.
 Arguments nth_safe_app [A] _ _ _ _.
 
-Hint Rewrite nth_map nth_ok_map nth_error_map : lists.
-Hint Rewrite nth_error_nil : lists.
-Hint Rewrite nth_error_in nth_error_out using lia : list_nth_error.
-Hint Rewrite nth_error_dec : list_nth_dec.
-Hint Resolve nth_error_value nth_error_error : datatypes.
+#[export] Hint Rewrite nth_map nth_ok_map nth_error_map : lists.
+#[export] Hint Rewrite nth_error_nil : lists.
+#[export] Hint Rewrite nth_error_in nth_error_out using lia : list_nth_error.
+#[export] Hint Rewrite nth_error_dec : list_nth_dec.
+#[export] Hint Resolve nth_error_value nth_error_error : datatypes.

--- a/coq/ott_list_nth.v
+++ b/coq/ott_list_nth.v
@@ -1,10 +1,10 @@
+(** * Nth element of a list **)
+
 Require Import Arith.
 Require Import Lia.
 Require Import List.
 Require Import Ott.ott_list_support.
 Require Import Ott.ott_list_base.
-
-
 
 Section Lists.
 
@@ -24,10 +24,6 @@ Ltac case_eq foo :=
   generalize (refl_equal foo);
   pattern foo at -1;
   case foo.
-
-
-
-(*** Nth element ***)
 
 Unset Implicit Arguments.
 

--- a/coq/ott_list_nth.v
+++ b/coq/ott_list_nth.v
@@ -35,13 +35,13 @@ Fixpoint nth_safe l n {struct l} : n < length l -> A :=
   match l as l1, n as n1 return n1 < length l1 -> A with
     | h::t, 0 => fun H => h
     | h::t, S m => fun H => nth_safe t m (le_S_n _ _ H)
-    | nil, _ => fun H => match le_Sn_O _ H with end
+    | nil, _ => fun H => match Nat.nle_succ_0 _ H with end
   end.
 
 Lemma nth_safe_eq_nth_error :
   forall l n H, value (nth_safe l n H) = nth_error l n.
 Proof.
-  induction l; intro n; pose (F := le_Sn_O n); destruct n; try (contradiction || tauto).
+  induction l; intro n; pose (F := Nat.nle_succ_0 n); destruct n; try (contradiction || tauto).
   simpl length; intro H. 
   simpl nth_error; rewrite <- (IHl n (le_S_n _ _ H)).
   reflexivity.
@@ -65,7 +65,7 @@ Lemma nth_safe_app :
   forall l l' n (H:n<length l),
     exists H', nth_safe l n H = nth_safe (l++l') n H'.
 Proof.
-  induction l; intros. solve [contradiction (le_Sn_O n H)].
+  induction l; intros. solve [contradiction (Nat.nle_succ_0 n H)].
   destruct n.
   simpl length. assert (H' : 0 < S (length (l ++ l')));
                   [solve [auto with arith] | exists H'; reflexivity].

--- a/coq/ott_list_predicate.v
+++ b/coq/ott_list_predicate.v
@@ -21,7 +21,7 @@ Set Implicit Arguments.
 
 Lemma not_Exists_list_nil : forall P, ~(Exists_list P nil).
 Proof. intros P H; inversion H. Qed.
-Hint Resolve not_Exists_list_nil : core.
+#[local] Hint Resolve not_Exists_list_nil : core.
 
 Lemma Forall_list_dec :
   forall P (dec : forall x, {P x} + {~P x}) l,
@@ -87,7 +87,7 @@ Proof.
   intros; induction l; simpl in * . assumption.
   inversion_clear H. auto.
 Qed.
-Hint Resolve app_Forall_list Forall_list_app_left Forall_list_app_right : core.
+#[local] Hint Resolve app_Forall_list Forall_list_app_left Forall_list_app_right : core.
 
 Lemma Exists_list_app_or :
   forall P l l', Exists_list P (l++l') ->
@@ -107,7 +107,7 @@ Lemma app_Exists_list_right :
 Proof.
   intros; induction l; simpl; auto.
 Qed.
-Hint Resolve Exists_list_app_or app_Exists_list_left app_Exists_list_right : core.
+#[local] Hint Resolve Exists_list_app_or app_Exists_list_left app_Exists_list_right : core.
 
 Lemma rev_Forall_list :
   forall P l, Forall_list P l -> Forall_list P (rev l).
@@ -167,17 +167,17 @@ Proof. induction 2; firstorder. Qed.
 
 End List_predicate_inductive.
 
-Hint Resolve not_Exists_list_nil : lists.
-Hint Resolve In_Forall_list : lists.
-Hint Resolve Forall_list_app_left Forall_list_app_right : lists.
-Hint Resolve app_Forall_list Exists_list_app_or : lists.
-Hint Resolve app_Exists_list_left app_Exists_list_right : lists.
-Hint Resolve rev_Forall_list rev_Exists_list : lists.
-Hint Resolve Forall_list_rev Exists_list_rev : lists.
-Hint Resolve take_Forall_list drop_Forall_list Forall_list_take_drop
-             take_drop_Exists_list Exists_list_take Exists_list_drop
-             : take_drop.
-Hint Resolve Forall_list_implies Exists_list_implies : lists.
+#[export] Hint Resolve not_Exists_list_nil : lists.
+#[export] Hint Resolve In_Forall_list : lists.
+#[export] Hint Resolve Forall_list_app_left Forall_list_app_right : lists.
+#[export] Hint Resolve app_Forall_list Exists_list_app_or : lists.
+#[export] Hint Resolve app_Exists_list_left app_Exists_list_right : lists.
+#[export] Hint Resolve rev_Forall_list rev_Exists_list : lists.
+#[export] Hint Resolve Forall_list_rev Exists_list_rev : lists.
+#[export] Hint Resolve take_Forall_list drop_Forall_list Forall_list_take_drop
+            take_drop_Exists_list Exists_list_take Exists_list_drop
+          : take_drop.
+#[export] Hint Resolve Forall_list_implies Exists_list_implies : lists.
 
 
 
@@ -381,11 +381,11 @@ Qed.
 
 End List_predicate_map.
 
-Hint Rewrite map_take map_drop : take_drop.
-Hint Resolve Forall_list_implies_map Exists_list_implies_map : lists.
-Hint Resolve Forall_list_map_implies Exists_list_map_implies : lists.
-Hint Resolve Forall_list_map_intro Exists_list_map_intro : lists.
-Hint Resolve Forall_list_map_elim Exists_list_map_elim : lists.
+#[export] Hint Rewrite map_take map_drop : take_drop.
+#[export] Hint Resolve Forall_list_implies_map Exists_list_implies_map : lists.
+#[export] Hint Resolve Forall_list_map_implies Exists_list_map_implies : lists.
+#[export] Hint Resolve Forall_list_map_intro Exists_list_map_intro : lists.
+#[export] Hint Resolve Forall_list_map_elim Exists_list_map_elim : lists.
 
 (* Simplify hypotheses and goals involving [Forall_list]. Simplifications
    involve rewriting [Forall_list ?P ?l] into equivalent statements

--- a/coq/ott_list_predicate.v
+++ b/coq/ott_list_predicate.v
@@ -1,4 +1,4 @@
-(*** Predicates on a list ***)
+(** * Predicates on a list *)
 
 Require Import Arith.
 Require Import Bool.
@@ -7,10 +7,9 @@ Require Import Ott.ott_list_base.
 Require Import Ott.ott_list_core.
 Require Import Ott.ott_list_takedrop.
 
-
-
 Section List_predicate_inductive.
-(* Properties of [Forall_list] and [Exists_list] *)
+
+(** Properties of [Forall_list] and [Exists_list] *)
 
 Variables A : Type.
 Implicit Types x : A.
@@ -182,7 +181,8 @@ End List_predicate_inductive.
 
 
 Section List_predicate_fold.
-(* Properties of [forall_list] and [exists_list] *)
+
+(** Properties of [forall_list] and [exists_list] *)
 
 Variables A : Type.
 Implicit Types x : A.
@@ -261,8 +261,6 @@ Qed.
 
 End List_predicate_fold.
 
-
-
 Section List_predicate_relationship.
 
 Variables A : Type.
@@ -289,10 +287,6 @@ Proof.
 Qed.
 
 End List_predicate_relationship.
-
-
-
-(*** More about maps ***)
 
 Section List_predicate_map.
 
@@ -387,7 +381,7 @@ End List_predicate_map.
 #[export] Hint Resolve Forall_list_map_intro Exists_list_map_intro : lists.
 #[export] Hint Resolve Forall_list_map_elim Exists_list_map_elim : lists.
 
-(* Simplify hypotheses and goals involving [Forall_list]. Simplifications
+(** Simplify hypotheses and goals involving [Forall_list]. Simplifications
    involve rewriting [Forall_list ?P ?l] into equivalent statements
    where [?l] is simpler. Recognised ``complex'' constructors for [?l]
    are [nil], [cons], [app], [map], [rev]. In the goal, only
@@ -423,4 +417,3 @@ Ltac simplify_Forall_list :=
              apply rev_Forall_list
             ); simpl)
   ).
-

--- a/coq/ott_list_repeat.v
+++ b/coq/ott_list_repeat.v
@@ -79,5 +79,5 @@ End Lists.
 
 
 
-Hint Rewrite repeat_length repeat_app repeat_S : lists.
-Hint Rewrite nth_error_repeat nth_repeat nth_safe_repeat : lists.
+#[export] Hint Rewrite repeat_length repeat_app repeat_S : lists.
+#[export] Hint Rewrite nth_error_repeat nth_repeat nth_safe_repeat : lists.

--- a/coq/ott_list_repeat.v
+++ b/coq/ott_list_repeat.v
@@ -1,4 +1,4 @@
-(*** Constant list ***)
+(** * Constant lists *)
 
 Require Import Arith.
 Require Import List.
@@ -7,8 +7,6 @@ Require Import Ott.ott_list_support.
 Require Import Ott.ott_list_base.
 Require Import Ott.ott_list_nth.
 Import List_lib_Arith.
-
-
 
 Section Lists.
 
@@ -76,8 +74,6 @@ Proof.
 Qed.
 
 End Lists.
-
-
 
 #[export] Hint Rewrite repeat_length repeat_app repeat_S : lists.
 #[export] Hint Rewrite nth_error_repeat nth_repeat nth_safe_repeat : lists.

--- a/coq/ott_list_support.v
+++ b/coq/ott_list_support.v
@@ -1,11 +1,7 @@
-(* Additional definitions and lemmas on lists *)
+(** * Support definitions and lemmas on lists *)
 
 Require Import Arith.
 Require Import Lia.
-
-
-
-(*** Support definitions and lemmas ***)
 
 Module List_lib_Arith.
 
@@ -20,8 +16,6 @@ Qed.
 
 End List_lib_Arith.
 
-
-
 Section functions.
   Set Implicit Arguments.
   Variables A B C D : Type.
@@ -29,8 +23,6 @@ Section functions.
   Definition compose2 (h:B->C->D) (f:A->B) (g:A->C) x y := h (f x) (g y).
 End functions.
 #[export] Hint Unfold compose compose2 : core.
-
-
 
 Section option.
   Set Implicit Arguments.

--- a/coq/ott_list_support.v
+++ b/coq/ott_list_support.v
@@ -28,7 +28,7 @@ Section functions.
   Definition compose (g:B->C) (f:A->B) x := g (f x).
   Definition compose2 (h:B->C->D) (f:A->B) (g:A->C) x y := h (f x) (g y).
 End functions.
-Hint Unfold compose compose2 : core.
+#[export] Hint Unfold compose compose2 : core.
 
 
 
@@ -50,4 +50,4 @@ Section option.
     end.
   Definition fold_error := fold_option.
 End option.
-Hint Unfold map_option map_error fold_option fold_error : core.
+#[export] Hint Unfold map_option map_error fold_option fold_error : core.

--- a/coq/ott_list_takedrop.v
+++ b/coq/ott_list_takedrop.v
@@ -224,17 +224,17 @@ Qed.
 
 End Lists.
 
-Hint Rewrite take_0 take_nil take_length take_nth take_take : take_drop.
-Hint Rewrite take_all : take_drop_short.
-Hint Rewrite take_some_length : take_drop_long.
-Hint Rewrite drop_0 drop_nil drop_length drop_nth drop_drop : take_drop.
-Hint Rewrite drop_all : take_drop_short.
-Hint Rewrite take_app_drop : take_drop.
-Hint Rewrite take_app_exact drop_app_exact : take_drop_exact.
-Hint Rewrite take_app_long drop_app_long : take_drop_long.
-Hint Rewrite take_app_short drop_app_short : take_drop.
-Hint Rewrite take_from_app drop_from_app : take_drop.
-Hint Rewrite take_take_app drop_take_app : take_drop_long.
+#[export] Hint Rewrite take_0 take_nil take_length take_nth take_take : take_drop.
+#[export] Hint Rewrite take_all : take_drop_short.
+#[export] Hint Rewrite take_some_length : take_drop_long.
+#[export] Hint Rewrite drop_0 drop_nil drop_length drop_nth drop_drop : take_drop.
+#[export] Hint Rewrite drop_all : take_drop_short.
+#[export] Hint Rewrite take_app_drop : take_drop.
+#[export] Hint Rewrite take_app_exact drop_app_exact : take_drop_exact.
+#[export] Hint Rewrite take_app_long drop_app_long : take_drop_long.
+#[export] Hint Rewrite take_app_short drop_app_short : take_drop.
+#[export] Hint Rewrite take_from_app drop_from_app : take_drop.
+#[export] Hint Rewrite take_take_app drop_take_app : take_drop_long.
 
 (* Break the list [original] into two pieces [prefix] and [suffix]
    at the location indicated by [cut_point]. [cut_point] indicates

--- a/coq/ott_list_takedrop.v
+++ b/coq/ott_list_takedrop.v
@@ -1,8 +1,6 @@
 (* Additional definitions and lemmas on lists *)
 
 Require Import Arith.
-Require Import Max.
-Require Import Min.
 Require Import List.
 Require Import Lia.
 Require Import Ott.ott_list_support.
@@ -51,7 +49,7 @@ Proof.
 Qed.
 
 Lemma take_length :
-  forall l n, length (take n l) = min n (length l).
+  forall l n, length (take n l) = Nat.min n (length l).
 Proof.
   induction l; destruct n; intros; simpl; try rewrite IHl; reflexivity.
 Qed.
@@ -76,10 +74,10 @@ Proof.
 Qed.
 
 Lemma take_take :
-  forall l m n, take m (take n l) = take (min m n) l.
+  forall l m n, take m (take n l) = take (Nat.min m n) l.
 Proof.
   induction l; intros; simpl.
-  destruct (min m n); destruct n; repeat rewrite take_nil; reflexivity.
+  destruct (Nat.min m n); destruct n; repeat rewrite take_nil; reflexivity.
   destruct n; destruct m; try reflexivity.
   simpl. rewrite IHl. reflexivity.
 Qed.
@@ -209,7 +207,7 @@ Lemma take_take_app :
   forall l l' n, n <= length l -> take n (take n l ++ l') = take n l.
 Proof.
   intros. rewrite take_app_long. rewrite take_take.
-  destruct (min_dec n n) as [Eq | Eq]; rewrite Eq; reflexivity.
+  destruct (Nat.min_dec n n) as [Eq | Eq]; rewrite Eq; reflexivity.
   rewrite take_some_length; trivial.
 Qed.
 

--- a/coq/ott_list_takedrop.v
+++ b/coq/ott_list_takedrop.v
@@ -1,4 +1,4 @@
-(* Additional definitions and lemmas on lists *)
+(** * Prefix and suffix extraction on lists **)
 
 Require Import Arith.
 Require Import List.
@@ -7,8 +7,6 @@ Require Import Ott.ott_list_support.
 Require Import Ott.ott_list_base.
 Require Import Ott.ott_list_nth.
 Import List_lib_Arith.
-
-
 
 Section Lists.
 
@@ -23,10 +21,6 @@ Implicit Types f : A -> B.
 Implicit Types g : B -> C.
 Implicit Types m n : nat.
 Set Implicit Arguments.
-
-
-
-(*** Prefix and suffix extraction ***)
 
 Fixpoint take n l {struct l} : list A :=
   match n, l with
@@ -218,10 +212,6 @@ Proof.
   apply take_some_length. assumption.
 Qed.
 
-
-
-(*** End of the Lists section ***)
-
 End Lists.
 
 #[export] Hint Rewrite take_0 take_nil take_length take_nth take_take : take_drop.
@@ -236,7 +226,7 @@ End Lists.
 #[export] Hint Rewrite take_from_app drop_from_app : take_drop.
 #[export] Hint Rewrite take_take_app drop_take_app : take_drop_long.
 
-(* Break the list [original] into two pieces [prefix] and [suffix]
+(** Break the list [original] into two pieces [prefix] and [suffix]
    at the location indicated by [cut_point]. [cut_point] indicates
    the number of elements to retain in [prefix]; it may also be
    a list whose length is used. This tactic leaves either one or two
@@ -244,7 +234,7 @@ End Lists.
    [prefix] is [cut_point]. The second goal has [original] left
    unchanged and an additional hypothesis stating that
    [length original < cut_point]; the tactic tries refuting this by
-   calling omega. *)
+   calling lia. *)
 Ltac cut_list original cut_point prefix suffix :=
   let l := fresh "whole" with Ineq := fresh "Ineq" with
       Eq := fresh "Decomposition" with Eql := fresh "Eqlen" with
@@ -255,16 +245,16 @@ Ltac cut_list original cut_point prefix suffix :=
              | _ => fail "cut_list: unrecognised cut_point type"
            end in (
     destruct (le_lt_dec n (length original)) as [Ineq | Ineq]; [
-      (**length original >= n, so length prefix = n**)
+      (** [length original >= n], so [length prefix = n] *)
       assert (Eql := take_some_length original Ineq); clear Ineq;
       generalize dependent original; intro l;
       assert (Eq := take_app_drop l n);
       set (p := (take n l)) in *; set (s := (drop n l)) in *;
       clearbody p s; subst l;
-      (*We've done the cutting, now we try to do some simplifications*)
+      (** We've done the cutting, now we try to do some simplifications *)
       autorewrite with lists take_drop; intros;
       rename p into prefix; rename s into suffix
-    | (**length original < n**)
+    | (** [length original < n] *)
       try (equate_list_lengths; lia) ]
   ).
 
@@ -308,8 +298,3 @@ Ltac parallel_split_maps :=
              clear Eqlen' H
            | H : _ ++ _ = map _ _ ++ map _ _ |- _ => symmetry in H
          end.
-
-
-
-
-(*** The End. ***)

--- a/coq/ott_list_takedrop.v
+++ b/coq/ott_list_takedrop.v
@@ -167,7 +167,7 @@ Lemma take_app_long :
 Proof.
   intros.
   set (tmp := l) in |- * at 2. rewrite <- (take_app_drop l n). subst tmp.
-  rewrite app_ass. rewrite take_app_exact. reflexivity.
+  rewrite <- app_assoc. rewrite take_app_exact. reflexivity.
   apply take_some_length. assumption.
 Qed.
 
@@ -176,7 +176,7 @@ Lemma drop_app_long :
 Proof.
   intros.
   set (tmp := l) in |- * at 2. rewrite <- (take_app_drop l n). subst tmp.
-  rewrite app_ass. rewrite drop_app_exact. reflexivity.
+  rewrite <- app_assoc. rewrite drop_app_exact. reflexivity.
   apply take_some_length. assumption.
 Qed.
 
@@ -193,7 +193,7 @@ Lemma take_from_app :
 Proof.
   intros. replace (length l) with (length l + 0). 2: lia.
   rewrite take_app_short. rewrite take_0.
-  symmetry. apply app_nil_end.
+  apply app_nil_r.
 Qed.
 
 Lemma drop_from_app :

--- a/examples/ocaml_light/.gitignore
+++ b/examples/ocaml_light/.gitignore
@@ -1,4 +1,7 @@
 *.vo
+*.vio
+*.vos
+*.vok
 *.glob
 *.v.d
 *.aux

--- a/examples/ocaml_light/Makefile
+++ b/examples/ocaml_light/Makefile
@@ -46,7 +46,7 @@ poly_lib = /Users/so294/polyml.5.1/lib
 #### Programs and their arguments ####
 COQC = coqc
 #COQ_INCLUDE = -I $(ott_coq_lib_dir)
-COQ_INCLUDE = -R $(ott_coq_lib_dir) Ott
+COQ_INCLUDE = -Q $(ott_coq_lib_dir) Ott
 COQ_FLAGS =
 DVIPS = dvips
 DVIPSFLAGS = -Ppdf -j0 -G0
@@ -200,7 +200,7 @@ hol/ocamlpp/filter:
 clean:
 	rm -f *.grammar *.rawtex
 	rm -f *.aux *.dvi *.lof *.log *.lot *.ps *.pdf *.toc
-	rm -f *.vo *.ui *.uo *.isa
+	rm -f *.vo *.vos *.vok *.glob *.ui *.uo *.isa
 	rm -f $(caml_combinations:=_syntax.ott) $(caml_combinations:=_typing.ott) $(caml_combinations:=_reduction.ott)
 	rm -f $(caml_combinations:=.tex) $(caml_combinations:=Script.sml) $(caml_combinations:=.thy) $(caml_combinations:=.v)
 	rm -f *Theory.sig *Theory.sml


### PR DESCRIPTION
This adds compatibility with Coq 8.19 and later and *conservatively* modernizes the Coq code:
- Coq library semantics becomes consistent across Coq versions by adding explicit locality for hints (this makes the minimum Coq version 8.14)
- update `Makefile` for Coq library to enable easily producing coqdoc documentation (`make html` in `coq` directory)
- update `.gitignore`s for Coq-related files
- consistent coqdoc comments in the Coq code to allow better documentation generation
- Coq checking tested with `ocaml_light` and lots of smaller examples

I will merge this in the next day or two unless there are concerns.