### PR TITLE
explicit export locality for Hint commands in all generated Coq code

### DIFF
--- a/src/grammar_pp.ml
+++ b/src/grammar_pp.ml
@@ -1250,7 +1250,7 @@ and coq_maybe_decide_equality m xd homs ntmvr loc =
         | [ Hom_string s ] -> s 
         | _ -> Auxl.error (Some loc) "malformed coq-equality homomorphism\n" )
       ^ "\nDefined.\n"
-      ^ "Hint Resolve eq_" ^ type_name  ^ " : ott_coq_equality.\n"
+      ^ "#[export] Hint Resolve eq_" ^ type_name  ^ " : ott_coq_equality.\n"
 
 and pp_metavardefn m xd mvd =
   let pp_com = pp_com_strings m xd mvd.mvd_rep [pp_metavar_with_sie m xd [] (mvd.mvd_name,[])] in

--- a/src/ln_transform.ml
+++ b/src/ln_transform.ml
@@ -1758,7 +1758,7 @@ Tactic Notation \"apply_fresh\" \"*\" constr(T) \"as\" ident(x) :=
     let h = hints_rel @ hints_lc in
     if List.length h = 0 
     then ""
-    else "Hint Constructors "^(String.concat " " h)^" : core.\n" in
+    else "#[export] Hint Constructors "^(String.concat " " h)^" : core.\n" in
 
   (* ** all together *)
   "\n(** infrastructure *)\n" 


### PR DESCRIPTION
This will make the Hint code have the same meaning in every Coq version supported.